### PR TITLE
Make the components tagless

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 ## Features
 
-- Provides an extremely generic way of describing a series of views that should be shown in succession
-- Provides absolutely CSS styling and the bare minimum HTML to stay out of the way of your code
+- Provides an extremely generic way of describing a series of views that should be shown in succession.
+- Non-intrusive as the addon components do not create additional HTML.
 
 ## Installation
 
@@ -20,7 +20,7 @@ ember install ember-steps
 
 ## Basic Usage
 
-Using `ember-steps` starts with creating a `step-manager`
+Using `ember-steps` starts with creating a `step-manager`.
 
 ```handlebars
 {{#step-manager as |w|}}
@@ -28,7 +28,7 @@ Using `ember-steps` starts with creating a `step-manager`
 {{/step-manager}}
 ```
 
-Cool, right?  Ehh, it doesn't do much yet -- we need to add some steps
+Cool, right?  Ehh, it doesn't do much yet -- we need to add some steps.
 
 ```handlebars
 {{#step-manager as |w|}}

--- a/addon/components/step-manager.js
+++ b/addon/components/step-manager.js
@@ -18,6 +18,8 @@ const layout = hbs`
 
 export default Component.extend({
   layout,
+  tagName: '',
+
   init() {
     this._super(...arguments);
 

--- a/addon/components/step-manager/step.js
+++ b/addon/components/step-manager/step.js
@@ -27,6 +27,18 @@ export default Component.extend({
     }
 
     this['register-step'](this);
+
+    // This is a hacky fix to make the addon work on Ember.js <= 2.8. The
+    // reason is that the VisibilitySupport mixin that is implemented in
+    // every component requires the component to be in the DOM. In particular,
+    // the line at https://github.com/emberjs/ember.js/blob/v2.8.0/packages/ember-views/lib/mixins/visibility_support.js#L46
+    // is failing.
+    //
+    // As the component is not rendered in the DOM, we don't need any of the
+    // functionality provided by VisibilitySupport. So the fix is "ok".
+    if (isFunction(this._toggleVisibility)) {
+      this._toggleVisibility = () => {};
+    }
   },
 
   /**
@@ -89,3 +101,7 @@ export default Component.extend({
     return get(this, 'hasInactiveState') || get(this, 'isActive');
   })
 });
+
+function isFunction(obj) {
+  return typeof obj === 'function' && typeof obj.nodeType !== 'number';
+}

--- a/addon/components/step-manager/step.js
+++ b/addon/components/step-manager/step.js
@@ -13,6 +13,7 @@ const layout = hbs`
 
 export default Component.extend({
   layout,
+  tagName: '',
 
   init() {
     this._super(...arguments);

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ember-hook": "^1.4.2",
     "ember-load-initializers": "^1.0.0",
     "ember-metrics": "^0.11.0",
+    "ember-native-dom-helpers": "^0.5.2",
     "ember-resolver": "^4.2.4",
     "ember-source": "^2.14.0",
     "ember-truth-helpers": "^1.3.0",

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -5,6 +5,7 @@ import { beforeEach, describe, it } from 'mocha';
 import td from 'testdouble';
 import hbs from 'htmlbars-inline-precompile';
 import { initialize as initializeEmberHook, $hook } from 'ember-hook';
+import { click, findAll } from 'ember-native-dom-helpers';
 
 const { matchers: { anything: matchAnything, contains: matchContains } } = td;
 const { A } = Ember;
@@ -144,7 +145,7 @@ describe('Integration: StepManagerComponent', function() {
           {{/step-manager}}
         `);
 
-        this.$('button').click();
+        click('button');
 
         expect(this.get('step')).to.equal('second');
       });
@@ -162,7 +163,7 @@ describe('Integration: StepManagerComponent', function() {
           {{/step-manager}}
         `);
 
-        this.$('button').click();
+        click('button');
 
         expect(this.get('step')).to.equal('second');
       });
@@ -180,7 +181,7 @@ describe('Integration: StepManagerComponent', function() {
           {{/step-manager}}
         `);
 
-        this.$('button').click();
+        click('button');
 
         expect(this.get('step')).to.equal('first');
       });
@@ -206,12 +207,14 @@ describe('Integration: StepManagerComponent', function() {
 
   it('renders tagless components', function() {
     this.render(hbs`
-      {{#step-manager as |w|}}
-        {{w.step}}
-      {{/step-manager}}
+      <div id="steps">
+        {{#step-manager as |w|}}
+          {{w.step}}
+        {{/step-manager}}
+      </div>
     `);
 
-    expect(this.$('*').toArray()).to.be.empty;
+    expect(findAll('#steps *')).to.be.empty;
   });
 
   describe('`yield`-ed data', function() {
@@ -251,7 +254,7 @@ describe('Integration: StepManagerComponent', function() {
       expect($hook('first')).to.be.visible;
       expect($hook('second')).not.to.be.visible;
 
-      this.$('button').click();
+      click('button');
 
       expect($hook('first')).not.to.be.visible;
       expect($hook('second')).to.be.visible;
@@ -269,7 +272,7 @@ describe('Integration: StepManagerComponent', function() {
           {{/step-manager}}
         `);
 
-        this.$('button').click();
+        click('button');
       }).to.throw(Error);
     });
   });
@@ -300,19 +303,19 @@ describe('Integration: StepManagerComponent', function() {
       expect($hook('second')).not.to.be.visible;
       expect($hook('third')).not.to.be.visible;
 
-      this.$('button').click();
+      click('button');
 
       expect($hook('first')).not.to.be.visible;
       expect($hook('second')).to.be.visible;
       expect($hook('third')).not.to.be.visible;
 
-      this.$('button').click();
+      click('button');
 
       expect($hook('first')).not.to.be.visible;
       expect($hook('second')).not.to.be.visible;
       expect($hook('third')).to.be.visible;
 
-      this.$('button').click();
+      click('button');
 
       expect($hook('first')).to.be.visible;
       expect($hook('second')).not.to.be.visible;
@@ -336,7 +339,7 @@ describe('Integration: StepManagerComponent', function() {
         {{/step-manager}}
       `);
 
-      this.$('button').click();
+      click('button');
 
       expect(onTransitionAction).to.be.called;
     });
@@ -356,7 +359,7 @@ describe('Integration: StepManagerComponent', function() {
         {{/step-manager}}
       `);
 
-      this.$('button').click();
+      click('button');
 
       expect(onTransitionAction).to.be.called;
     });
@@ -376,7 +379,7 @@ describe('Integration: StepManagerComponent', function() {
             </button>
           {{/step-manager}}
         `);
-        this.$('button').click();
+        click('button');
 
         expect(action).to.be.calledWith(
           matchContains({
@@ -400,7 +403,7 @@ describe('Integration: StepManagerComponent', function() {
             </button>
           {{/step-manager}}
         `);
-        this.$('button').click();
+        click('button');
 
         expect(action).to.be.calledWith(
           matchContains({
@@ -439,7 +442,7 @@ describe('Integration: StepManagerComponent', function() {
           </button>
         {{/step-manager}}
       `);
-      this.$('button').click();
+      click('button');
 
       expect(beforeAction).to.be.called;
     });
@@ -458,7 +461,7 @@ describe('Integration: StepManagerComponent', function() {
           </button>
         {{/step-manager}}
       `);
-      this.$('button').click();
+      click('button');
 
       expect(beforeAction).to.be.called;
     });
@@ -478,7 +481,7 @@ describe('Integration: StepManagerComponent', function() {
             </button>
           {{/step-manager}}
         `);
-        this.$('button').click();
+        click('button');
 
         expect(beforeAction).to.be.calledWith(
           matchContains({
@@ -502,7 +505,7 @@ describe('Integration: StepManagerComponent', function() {
             </button>
           {{/step-manager}}
         `);
-        this.$('button').click();
+        click('button');
 
         expect(beforeAction).to.be.calledWith(
           matchContains({
@@ -533,7 +536,7 @@ describe('Integration: StepManagerComponent', function() {
         {{/step-manager}}
       `);
 
-      this.$('button').click();
+      click('button');
 
       expect($hook('first')).to.be.visible;
       expect($hook('second')).not.to.be.visible;
@@ -560,7 +563,7 @@ describe('Integration: StepManagerComponent', function() {
       expect($hook('step', { index: 0 })).to.be.visible;
       expect($hook('step', { index: 1 })).not.to.be.visible;
 
-      this.$('button').click();
+      click('button');
 
       expect($hook('step', { index: 0 })).not.to.be.visible;
       expect($hook('step', { index: 1 })).to.be.visible;
@@ -602,13 +605,15 @@ describe('Integration: StepManagerComponent', function() {
     it('allows dynamically creating steps', function() {
       this.render(hbs`
         {{#step-manager currentStep=(unbound data.firstObject.name) as |w|}}
-          {{#each data as |item|}}
-            {{#w.step name=(unbound item.name)}}
-              <div data-test={{hook 'step' name=item.name}}>
-                {{item.name}}
-              </div>
-            {{/w.step}}
-          {{/each}}
+          <div data-test={{hook 'steps'}}>
+            {{#each data as |item|}}
+              {{#w.step name=(unbound item.name)}}
+                <div data-test={{hook 'step' name=item.name}}>
+                  {{item.name}}
+                </div>
+              {{/w.step}}
+            {{/each}}
+          </div>
 
           <button {{action w.transition-to-next}}>
             Next
@@ -618,25 +623,27 @@ describe('Integration: StepManagerComponent', function() {
 
       expect($hook('step', { name: 'foo' })).to.be.visible;
       expect($hook('step', { name: 'bar' })).not.to.be.visible;
-      expect(this.$()).to.contain('foo');
+      expect($hook('steps').text().trim()).to.equal('foo');
 
-      this.$('button').click();
+      click('button');
 
       expect($hook('step', { name: 'foo' })).not.to.be.visible;
       expect($hook('step', { name: 'bar' })).to.be.visible;
-      expect(this.$()).to.contain('bar');
+      expect($hook('steps').text().trim()).to.equal('bar');
     });
 
     it('allows for adding more steps after the initial render', function() {
       this.render(hbs`
         {{#step-manager currentStep=(unbound data.firstObject.name) as |w|}}
-          {{#each data as |item|}}
-            {{#w.step name=(unbound item.name)}}
-              <div data-test={{hook 'step' name=item.name}}>
-                {{item.name}}
-              </div>
-            {{/w.step}}
-          {{/each}}
+          <div data-test={{hook 'steps'}}>
+            {{#each data as |item|}}
+              {{#w.step name=(unbound item.name)}}
+                <div data-test={{hook 'step' name=item.name}}>
+                  {{item.name}}
+                </div>
+              {{/w.step}}
+            {{/each}}
+          </div>
 
           <button {{action w.transition-to-next}}>
             Next
@@ -644,7 +651,7 @@ describe('Integration: StepManagerComponent', function() {
         {{/step-manager}}
       `);
 
-      this.$('button').click();
+      click('button');
 
       this.set('data', A([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]));
 
@@ -653,20 +660,20 @@ describe('Integration: StepManagerComponent', function() {
       expect($hook('step', { name: 'baz' })).not.to.be.visible;
 
       // Check that the previous "last step" now points to the new one
-      this.$('button').click();
+      click('button');
 
       expect($hook('step', { name: 'foo' })).not.to.be.visible;
       expect($hook('step', { name: 'bar' })).not.to.be.visible;
       expect($hook('step', { name: 'baz' })).to.be.visible;
-      expect(this.$()).to.contain('baz');
+      expect($hook('steps').text().trim()).to.equal('baz');
 
       // Check that the new step now points to the first one
-      this.$('button').click();
+      click('button');
 
       expect($hook('step', { name: 'foo' })).to.be.visible;
       expect($hook('step', { name: 'bar' })).not.to.be.visible;
       expect($hook('step', { name: 'baz' })).not.to.be.visible;
-      expect(this.$()).to.contain('foo');
+      expect($hook('steps').text().trim()).to.equal('foo');
     });
   });
 });

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -21,26 +21,36 @@ describe('Integration: StepManagerComponent', function() {
       it('can use a primitive value', function() {
         this.render(hbs`
           {{#step-manager currentStep='second' as |w|}}
-            {{w.step name='first'}}
-            {{w.step name='second'}}
+            {{#w.step name='first'}}
+              <div data-test={{hook 'first'}}></div>
+            {{/w.step}}
+
+            {{#w.step name='second'}}
+              <div data-test={{hook 'second'}}></div>
+            {{/w.step}}
           {{/step-manager}}
         `);
 
-        expect($hook('step', { name: 'first' })).not.to.be.visible;
-        expect($hook('step', { name: 'second' })).to.be.visible;
+        expect($hook('first')).not.to.be.visible;
+        expect($hook('second')).to.be.visible;
       });
 
       it('can use a value from the `mut` helper', function() {
         this.set('currentStep', 'second');
         this.render(hbs`
           {{#step-manager currentStep=(mut currentStep) as |w|}}
-            {{w.step name='first'}}
-            {{w.step name='second'}}
+            {{#w.step name='first'}}
+              <div data-test={{hook 'first'}}></div>
+            {{/w.step}}
+
+            {{#w.step name='second'}}
+              <div data-test={{hook 'second'}}></div>
+            {{/w.step}}
           {{/step-manager}}
         `);
 
-        expect($hook('step', { name: 'first' })).not.to.be.visible;
-        expect($hook('step', { name: 'second' })).to.be.visible;
+        expect($hook('first')).not.to.be.visible;
+        expect($hook('second')).to.be.visible;
       });
     });
 
@@ -49,55 +59,70 @@ describe('Integration: StepManagerComponent', function() {
         this.set('step', 'first');
         this.render(hbs`
           {{#step-manager currentStep=step as |w|}}
-            {{w.step name='first'}}
-            {{w.step name='second'}}
+            {{#w.step name='first'}}
+              <div data-test={{hook 'first'}}></div>
+            {{/w.step}}
+
+            {{#w.step name='second'}}
+              <div data-test={{hook 'second'}}></div>
+            {{/w.step}}
           {{/step-manager}}
         `);
 
-        expect($hook('step', { name: 'first' })).to.be.visible;
-        expect($hook('step', { name: 'second' })).not.to.be.visible;
+        expect($hook('first')).to.be.visible;
+        expect($hook('second')).not.to.be.visible;
 
         this.set('step', 'second');
 
-        expect($hook('step', { name: 'first' })).not.to.be.visible;
-        expect($hook('step', { name: 'second' })).to.be.visible;
+        expect($hook('first')).not.to.be.visible;
+        expect($hook('second')).to.be.visible;
 
         // Important for binding current step to a query param
         this.set('step', undefined);
 
-        expect($hook('step', { name: 'first' })).to.be.visible;
-        expect($hook('step', { name: 'second' })).not.to.be.visible;
+        expect($hook('first')).to.be.visible;
+        expect($hook('second')).not.to.be.visible;
       });
 
       it('changes steps when the property changes (with the mut helper)', function() {
         this.set('step', 'first');
         this.render(hbs`
           {{#step-manager currentStep=(mut step) as |w|}}
-            {{w.step name='first'}}
-            {{w.step name='second'}}
+            {{#w.step name='first'}}
+              <div data-test={{hook 'first'}}></div>
+            {{/w.step}}
+
+            {{#w.step name='second'}}
+              <div data-test={{hook 'second'}}></div>
+            {{/w.step}}
           {{/step-manager}}
         `);
 
-        expect($hook('step', { name: 'first' })).to.be.visible;
-        expect($hook('step', { name: 'second' })).not.to.be.visible;
+        expect($hook('first')).to.be.visible;
+        expect($hook('second')).not.to.be.visible;
 
         this.set('step', 'second');
 
-        expect($hook('step', { name: 'first' })).not.to.be.visible;
-        expect($hook('step', { name: 'second' })).to.be.visible;
+        expect($hook('first')).not.to.be.visible;
+        expect($hook('second')).to.be.visible;
       });
 
       it.skip('throws an error when an invalid step is provided', function() {
         this.set('step', 'first');
         this.render(hbs`
           {{#step-manager currentStep=step as |w|}}
-            {{w.step name='first'}}
-            {{w.step name='second'}}
+            {{#w.step name='first'}}
+              <div data-test={{hook 'first'}}></div>
+            {{/w.step}}
+
+            {{#w.step name='second'}}
+              <div data-test={{hook 'second'}}></div>
+            {{/w.step}}
           {{/step-manager}}
         `);
 
-        expect($hook('step', { name: 'first' })).to.be.visible;
-        expect($hook('step', { name: 'second' })).not.to.be.visible;
+        expect($hook('first')).to.be.visible;
+        expect($hook('second')).not.to.be.visible;
 
         expect(() => {
           this.set('step', 'foobar');
@@ -165,26 +190,33 @@ describe('Integration: StepManagerComponent', function() {
   it('renders the first step in the DOM if no `currentStep` is present', function() {
     this.render(hbs`
       {{#step-manager as |w|}}
-        {{w.step name='first'}}
-        {{w.step name='second'}}
+        {{#w.step name='first'}}
+          <div data-test={{hook 'first'}}></div>
+        {{/w.step}}
+
+        {{#w.step name='second'}}
+          <div data-test={{hook 'second'}}></div>
+        {{/w.step}}
       {{/step-manager}}
     `);
 
-    expect($hook('step', { name: 'first' })).to.be.visible;
-    expect($hook('step', { name: 'second' })).not.to.be.visible;
+    expect($hook('first')).to.be.visible;
+    expect($hook('second')).not.to.be.visible;
   });
 
   describe('`yield`-ed data', function() {
     it('exposes the name of the current step', function() {
       this.render(hbs`
         {{#step-manager as |w|}}
-          {{w.currentStep}}
+          <div data-test={{hook 'steps'}}>
+            {{w.currentStep}}
 
-          {{w.step name='foo'}}
+            {{w.step name='foo'}}
+          </div>
         {{/step-manager}}
       `);
 
-      expect($hook('step-manager')).to.contain('foo');
+      expect($hook('steps')).to.contain('foo');
     });
   });
 
@@ -196,18 +228,23 @@ describe('Integration: StepManagerComponent', function() {
             Transition to Next
           </button>
 
-          {{w.step name='first'}}
-          {{w.step name='second'}}
+          {{#w.step name='first'}}
+            <div data-test={{hook 'first'}}></div>
+          {{/w.step}}
+
+          {{#w.step name='second'}}
+            <div data-test={{hook 'second'}}></div>
+          {{/w.step}}
         {{/step-manager}}
       `);
 
-      expect($hook('step', { name: 'first' })).to.be.visible;
-      expect($hook('step', { name: 'second' })).not.to.be.visible;
+      expect($hook('first')).to.be.visible;
+      expect($hook('second')).not.to.be.visible;
 
       this.$('button').click();
 
-      expect($hook('step', { name: 'first' })).not.to.be.visible;
-      expect($hook('step', { name: 'second' })).to.be.visible;
+      expect($hook('first')).not.to.be.visible;
+      expect($hook('second')).to.be.visible;
     });
 
     it.skip('errors when transitioning to an invalid step', function() {
@@ -235,33 +272,41 @@ describe('Integration: StepManagerComponent', function() {
             Next!
           </button>
 
-          {{w.step id='first'}}
-          {{w.step id='second'}}
-          {{w.step id='third'}}
+          {{#w.step name='first'}}
+            <div data-test={{hook 'first'}}></div>
+          {{/w.step}}
+
+          {{#w.step name='second'}}
+            <div data-test={{hook 'second'}}></div>
+          {{/w.step}}
+
+          {{#w.step name='third'}}
+            <div data-test={{hook 'third'}}></div>
+          {{/w.step}}
         {{/step-manager}}
       `);
 
-      expect(this.$('#first')).to.be.visible;
-      expect(this.$('#second')).not.to.be.visible;
-      expect(this.$('#third')).not.to.be.visible;
+      expect($hook('first')).to.be.visible;
+      expect($hook('second')).not.to.be.visible;
+      expect($hook('third')).not.to.be.visible;
 
       this.$('button').click();
 
-      expect(this.$('#first')).not.to.be.visible;
-      expect(this.$('#second')).to.be.visible;
-      expect(this.$('#third')).not.to.be.visible;
+      expect($hook('first')).not.to.be.visible;
+      expect($hook('second')).to.be.visible;
+      expect($hook('third')).not.to.be.visible;
 
       this.$('button').click();
 
-      expect(this.$('#first')).not.to.be.visible;
-      expect(this.$('#second')).not.to.be.visible;
-      expect(this.$('#third')).to.be.visible;
+      expect($hook('first')).not.to.be.visible;
+      expect($hook('second')).not.to.be.visible;
+      expect($hook('third')).to.be.visible;
 
       this.$('button').click();
 
-      expect(this.$('#first')).to.be.visible;
-      expect(this.$('#second')).not.to.be.visible;
-      expect(this.$('#third')).not.to.be.visible;
+      expect($hook('first')).to.be.visible;
+      expect($hook('second')).not.to.be.visible;
+      expect($hook('third')).not.to.be.visible;
     });
   });
 
@@ -464,8 +509,13 @@ describe('Integration: StepManagerComponent', function() {
 
       this.render(hbs`
         {{#step-manager will-transition=(action 'beforeAction') as |w|}}
-          {{w.step name='first'}}
-          {{w.step name='second'}}
+          {{#w.step name='first'}}
+            <div data-test={{hook 'first'}}></div>
+          {{/w.step}}
+
+          {{#w.step name='second'}}
+            <div data-test={{hook 'second'}}></div>
+          {{/w.step}}
 
           <button {{action w.transition-to-next}}>
             Next
@@ -475,8 +525,8 @@ describe('Integration: StepManagerComponent', function() {
 
       this.$('button').click();
 
-      expect($hook('step', { name: 'first' })).to.be.visible;
-      expect($hook('step', { name: 'second' })).not.to.be.visible;
+      expect($hook('first')).to.be.visible;
+      expect($hook('second')).not.to.be.visible;
     });
   });
 
@@ -484,8 +534,12 @@ describe('Integration: StepManagerComponent', function() {
     it('works outside of a loop', function() {
       this.render(hbs`
         {{#step-manager as |w|}}
-          {{w.step}}
-          {{w.step}}
+          {{#w.step}}
+            <div data-test={{hook 'step' index=0}}></div>
+          {{/w.step}}
+          {{#w.step}}
+            <div data-test={{hook 'step' index=1}}></div>
+          {{/w.step}}
 
           <button {{action w.transition-to-next}}>
             Next
@@ -507,17 +561,21 @@ describe('Integration: StepManagerComponent', function() {
     it('property is added by the HTMLBars transform', function() {
       this.render(hbs`
         {{#step-manager as |w|}}
-          {{#w.step}}
-            Active
-          {{else}}
-            Inactive
-          {{/w.step}}
+          <div data-test={{hook 'step' index=0}}>
+            {{#w.step}}
+              Active
+            {{else}}
+              Inactive
+            {{/w.step}}
+          </div>
 
-          {{#w.step}}
-            Active
-          {{else}}
-            Inactive
-          {{/w.step}}
+          <div data-test={{hook 'step' index=1}}>
+            {{#w.step}}
+              Active
+            {{else}}
+              Inactive
+            {{/w.step}}
+          </div>
         {{/step-manager}}
       `);
 
@@ -536,7 +594,9 @@ describe('Integration: StepManagerComponent', function() {
         {{#step-manager currentStep=(unbound data.firstObject.name) as |w|}}
           {{#each data as |item|}}
             {{#w.step name=(unbound item.name)}}
-              {{item.name}}
+              <div data-test={{hook 'step' name=item.name}}>
+                {{item.name}}
+              </div>
             {{/w.step}}
           {{/each}}
 
@@ -562,7 +622,9 @@ describe('Integration: StepManagerComponent', function() {
         {{#step-manager currentStep=(unbound data.firstObject.name) as |w|}}
           {{#each data as |item|}}
             {{#w.step name=(unbound item.name)}}
-              {{item.name}}
+              <div data-test={{hook 'step' name=item.name}}>
+                {{item.name}}
+              </div>
             {{/w.step}}
           {{/each}}
 

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -204,6 +204,16 @@ describe('Integration: StepManagerComponent', function() {
     expect($hook('second')).not.to.be.visible;
   });
 
+  it('renders tagless components', function() {
+    this.render(hbs`
+      {{#step-manager as |w|}}
+        {{w.step}}
+      {{/step-manager}}
+    `);
+
+    expect(this.$('*').toArray()).to.be.empty;
+  });
+
   describe('`yield`-ed data', function() {
     it('exposes the name of the current step', function() {
       this.render(hbs`

--- a/tests/integration/step-manager/step-test.js
+++ b/tests/integration/step-manager/step-test.js
@@ -104,7 +104,9 @@ describe('Integration: StepManagerStepComponent', function() {
     it('renders block content when visible', function() {
       this.render(hbs`
         {{#step-manager/step name='foo' isActive=true register-step=(action 'register')}}
-          Foo
+          <div data-test={{hook 'step'}}>
+            Foo
+          </div>
         {{/step-manager/step}}
       `);
 
@@ -115,24 +117,26 @@ describe('Integration: StepManagerStepComponent', function() {
       it('is hidden when no alternate state is provided', function() {
         this.render(hbs`
           {{#step-manager/step name='foo' register-step=(action 'register')}}
-            Active Content
+            <div data-test={{hook 'step'}}>
+              Active Content
+            </div>
           {{/step-manager/step}}
         `);
 
         expect($hook('step')).not.to.be.visible;
-        expect($hook('step')).not.to.contain('Active Content');
       });
 
       it('renders the inverse block if provided', function() {
         this.render(hbs`
-          {{#step-manager/step name='foo' hasInactiveState=true register-step=(action 'register')}}
-            Active Content
-          {{else}}
-            Inactive Content
-          {{/step-manager/step}}
+          <div data-test={{hook 'step'}}>
+            {{#step-manager/step name='foo' hasInactiveState=true register-step=(action 'register')}}
+              Active Content
+            {{else}}
+              Inactive Content
+            {{/step-manager/step}}
+          </div>
         `);
 
-        expect($hook('step')).to.be.visible;
         expect($hook('step')).to.contain('Inactive Content');
       });
     });
@@ -141,7 +145,9 @@ describe('Integration: StepManagerStepComponent', function() {
   describe('programmatically controlling visibility', function() {
     it('is visible when active', function() {
       this.render(hbs`
-        {{step-manager/step name='foo' isActive=true register-step=(action 'register')}}
+        {{#step-manager/step name='foo' isActive=true register-step=(action 'register')}}
+          <div data-test={{hook 'step'}}></div>
+        {{/step-manager/step}}
       `);
 
       expect($hook('step')).to.be.visible;
@@ -149,7 +155,9 @@ describe('Integration: StepManagerStepComponent', function() {
 
     it('is invisible when not active', function() {
       this.render(hbs`
-        {{step-manager/step name='foo' register-step=(action 'register')}}
+        {{#step-manager/step name='foo' register-step=(action 'register')}}
+          <div data-test={{hook 'step'}}></div>
+        {{/step-manager/step}}
       `);
 
       expect($hook('step')).not.to.be.visible;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3018,6 +3018,13 @@ ember-mocha@^0.12.0:
   dependencies:
     ember-test-helpers "^0.6.3"
 
+ember-native-dom-helpers@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.2.tgz#ba6123230fc32c3350f90a8f9183584a022215fa"
+  dependencies:
+    broccoli-funnel "^1.1.0"
+    ember-cli-babel "^6.1.0"
+
 "ember-prop-types@>=2.0.0 <4.0.0":
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/ember-prop-types/-/ember-prop-types-3.12.0.tgz#2939a7ddb95155ab0f2eba591176600f0d411a20"


### PR DESCRIPTION
This addresses issue #65. To recap, the advantages of not adding DOM nodes for the `{{step-manager}}` and `{{step-manager/step}}` components are:

* Easier styling as the steps wouldn't interfere with flexbox.
* I don't have any numbers but I'm imagining there's a small performance gain when rendering the page simply due to less DOM elements needed to render.

The user can always add his own DOM wrappers or set `tagName` manually on the step or step manager.

@alexlafroscia Let me know what you think! It's a breaking change so you might want to up the major version if you decide to release it.