### PR TITLE
Possibility to have an asynchronous process in "will-transition" action

### DIFF
--- a/addon/components/step-manager.js
+++ b/addon/components/step-manager.js
@@ -82,7 +82,7 @@ export default Component.extend({
    * @param {*} value the value to pass to the transition actions
    * @private
    */
-  'do-transition'(to, from, value) {
+  'do-transition'(to, from, value, direction) {
     // Update the `currentStep` if it's mutable
     if (this.attrs.currentStep && this.attrs.currentStep.update) {
       this.attrs.currentStep.update(to);
@@ -92,7 +92,7 @@ export default Component.extend({
     get(this, 'transitions').activate(to);
 
     if (this['did-transition']) {
-      this['did-transition']({ value, from, to });
+      this['did-transition']({ value, from, to, direction });
     }
   },
 
@@ -134,9 +134,10 @@ export default Component.extend({
    * If provided, this action will be called with a single POJO as the
    * argument, containing:
    *
-   * - `value`-> The value passed to the transition action, or `undefined`
-   * - `from` -> The name of the step being transitioned from
-   * - `to`   -> The name of the step being transitioned to
+   * - `value`     -> The value passed to the transition action, or `undefined`
+   * - `from`      -> The name of the step being transitioned from
+   * - `to`        -> The name of the step being transitioned to
+   * - `direction` -> The direction of the transition when using transition-to-next or transition-to-previous
    *
    * The action is called before the next step is activated.
    *
@@ -157,9 +158,10 @@ export default Component.extend({
    * If provided, this action will be called with a single POJO as the
    * argument, containing:
    *
-   * - `value`-> The value passed to the transition action, or `undefined`
-   * - `from` -> The name of the step being transitioned from
-   * - `to`   -> The name of the step being transitioned to
+   * - `value`     -> The value passed to the transition action, or `undefined`
+   * - `from`      -> The name of the step being transitioned from
+   * - `to`        -> The name of the step being transitioned to
+   * - `direction` -> The direction of the transition when using transition-to-next or transition-to-previous
    *
    * The action is called after the next step is activated.
    *
@@ -231,7 +233,7 @@ export default Component.extend({
      * @param {*} value the value to pass to the transition actions
      * @public
      */
-    'transition-to-step'(to, value) {
+    'transition-to-step'(to, value, direction) {
       const from = get(this, 'transitions.currentStep');
       const validator = this['will-transition'];
 
@@ -243,17 +245,17 @@ export default Component.extend({
       if (validator && typeof validator === 'function') {
         set(this, 'loading', true);
 
-        RSVP.resolve(validator({ value, from, to }))
+        RSVP.resolve(validator({ value, from, to, direction }))
           .then(result => {
             if (result !== false) {
-              this['do-transition'](to, from, value);
+              this['do-transition'](to, from, value, direction);
             }
           })
           .finally(() => {
             set(this, 'loading', false);
           });
       } else {
-        this['do-transition'](to, from, value);
+        this['do-transition'](to, from, value, direction);
       }
     },
 
@@ -273,7 +275,7 @@ export default Component.extend({
     'transition-to-next-step'(value) {
       const to = get(this, 'transitions').pickNext();
 
-      this.send('transition-to-step', to, value);
+      this.send('transition-to-step', to, value, 'next');
     },
 
     /**
@@ -291,7 +293,7 @@ export default Component.extend({
     'transition-to-previous-step'(value) {
       const to = get(this, 'transitions').pickPrevious();
 
-      this.send('transition-to-step', to, value);
+      this.send('transition-to-step', to, value, 'previous');
     }
   }
 });

--- a/addon/components/step-manager.js
+++ b/addon/components/step-manager.js
@@ -242,18 +242,16 @@ export default Component.extend({
       if (validator && typeof validator === 'function') {
         const result = validator({ value, from, to });
 
-        if (result) {
-          if (typeof result.then === 'function') {
-            set(this, 'loading', true);
-            result
-              .then(() => {
-                this.send('make-transition', to, from, value);
-              }, null)
-              .finally(() => {
-                set(this, 'loading', false);
-              });
-            return;
-          }
+        if (result && typeof result.then === 'function') {
+          set(this, 'loading', true);
+          result
+            .then(() => {
+              this.send('make-transition', to, from, value);
+            }, null)
+            .finally(() => {
+              set(this, 'loading', false);
+            });
+          return;
         } else if (result === false) {
           return;
         }

--- a/addon/components/step-manager.js
+++ b/addon/components/step-manager.js
@@ -73,6 +73,29 @@ export default Component.extend({
   _lastStep: undefined,
 
   /**
+   * Used internally to transition to a specific named step
+   *
+   * @method do-transition
+   * @param {string} to the name of the step to transition to
+   * @param {string} from the name of the step being transitioned
+   * @param {*} value the value to pass to the transition actions
+   * @private
+   */
+  'do-transition'(to, from, value) {
+    // Update the `currentStep` if it's mutable
+    if (this.attrs.currentStep && this.attrs.currentStep.update) {
+      this.attrs.currentStep.update(to);
+    }
+
+    // Activate the next step
+    get(this, 'transitions').activate(to);
+
+    if (this['did-transition']) {
+      this['did-transition']({ value, from, to });
+    }
+  },
+
+  /**
    * The `currentStep` property can be used for providing, or binding to, the
    * name of the current step.
    *
@@ -187,29 +210,6 @@ export default Component.extend({
     },
 
     /**
-     * Used internally to transition to a specific named step
-     *
-     * @method make-transition
-     * @param {string} to the name of the step to transition to
-     * @param {string} from the name of the step being transitioned
-     * @param {*} value the value to pass to the transition actions
-     * @private
-     */
-    'make-transition'(to, from, value) {
-      // Update the `currentStep` if it's mutable
-      if (this.attrs.currentStep && this.attrs.currentStep.update) {
-        this.attrs.currentStep.update(to);
-      }
-
-      // Activate the next step
-      get(this, 'transitions').activate(to);
-
-      if (this['did-transition']) {
-        this['did-transition']({ value, from, to });
-      }
-    },
-
-    /**
      * Transition to a named step
      *
      * If you have provided a `will-transition` action, it will call the action
@@ -246,7 +246,7 @@ export default Component.extend({
           set(this, 'loading', true);
           result
             .then(() => {
-              this.send('make-transition', to, from, value);
+              this['do-transition'](to, from, value);
             }, null)
             .finally(() => {
               set(this, 'loading', false);
@@ -257,7 +257,7 @@ export default Component.extend({
         }
       }
 
-      this.send('make-transition', to, from, value);
+      this['do-transition'](to, from, value);
     },
 
     /**

--- a/tests/dummy/app/application/template.hbs
+++ b/tests/dummy/app/application/template.hbs
@@ -14,6 +14,7 @@
       {{link-to 'Basic Usage' 'index' local-class="nav-item"}}
       {{link-to 'Named Steps' 'named-steps' local-class="nav-item"}}
       {{link-to 'Step Links' 'step-links' local-class="nav-item"}}
+      {{link-to 'Validator usage' 'validator' local-class="nav-item"}}
     </nav>
 
   </div>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -27,6 +27,7 @@ const Router = EmberRouter.extend({
 Router.map(function() {
   this.route('named-steps');
   this.route('step-links');
+  this.route('validator');
 });
 
 export default Router;

--- a/tests/dummy/app/validator/controller.js
+++ b/tests/dummy/app/validator/controller.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+import RSVP from 'rsvp';
+
+const { Controller } = Ember;
+
+export default Controller.extend({
+  // BEGIN-SNIPPET validator
+  validationFailed: false,
+
+  actions: {
+    validator(payload) {
+      const { run } = Ember;
+      let promise;
+      this.set('validationFailed', false);
+
+      if (payload.from == 'b') {
+        promise = new RSVP.Promise((resolve, reject) => {
+          run.later(
+            null,
+            () => {
+              this.set('validationFailed', true);
+              reject();
+            },
+            1000
+          );
+        });
+      } else {
+        promise = new RSVP.Promise(resolve => {
+          run.later(null, resolve, 1000);
+        });
+      }
+
+      return promise;
+    }
+  }
+  // END-SNIPPET
+});

--- a/tests/dummy/app/validator/route.js
+++ b/tests/dummy/app/validator/route.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  titleToken: 'Validator usage'
+});

--- a/tests/dummy/app/validator/template.hbs
+++ b/tests/dummy/app/validator/template.hbs
@@ -1,7 +1,7 @@
 {{#usage-example title='Validator usage'}}
   {{#block-slot 'rendered'}}
     <p>
-      A common use-case might be to validate a step, so you can prevent leaving the step. This could be used to create an experience where a user typed-in values that need to be validated by the server.
+      A common use-case might be to validate a step, so you can prevent leaving the step. This could be used to create an experience where a user typed in values that need to be validated by the server.
     </p>
 
     <hr />

--- a/tests/dummy/app/validator/template.hbs
+++ b/tests/dummy/app/validator/template.hbs
@@ -1,0 +1,51 @@
+{{#usage-example title='Validator usage'}}
+  {{#block-slot 'rendered'}}
+    <p>
+      A common use-case might be to validate a step, so you can prevent leaving the step. This could be used to create an experience where a user typed-in values that need to be validated by the server.
+    </p>
+
+    <hr />
+
+    {{!-- BEGIN-SNIPPET validator --}}
+    {{#step-manager will-transition=(action 'validator') as |w|}}
+      <div>
+        {{#each w.steps as |step|}}
+        <div>
+          <span>Step {{step}}</span>
+          {{#if (eq step w.currentStep)}}
+            {{#if w.loading}}
+            <span>: validating</span>
+            {{/if}}
+            {{#if validationFailed}}
+            <span>: validation failed</span>
+            {{/if}}
+          {{/if}}
+        </div>
+        {{/each}}
+      </div>
+      <button {{action w.transition-to-next}}>
+        Go to next step
+      </button>
+
+      {{#w.step name='a'}}
+        <h3>Step A</h3>
+      {{/w.step}}
+
+      {{#w.step name='b'}}
+        <h3>Step B</h3>
+      {{/w.step}}
+
+      {{#w.step name='c'}}
+        <h3>Step C</h3>
+      {{/w.step}}
+    {{/step-manager}}
+    {{!-- END-SNIPPET --}}
+  {{/block-slot}}
+
+  {{#block-slot 'code-template'}}
+    {{code-snippet name='validator.hbs'}}
+  {{/block-slot}}
+  {{#block-slot 'code-js'}}
+    {{code-snippet name='validator.js'}}
+  {{/block-slot}}
+{{/usage-example}}

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -674,7 +674,9 @@ describe('Integration: StepManagerComponent', function() {
         .then(done, done);
     });
 
-    it('prevents the transition if the promise resolve to `false`', function(done) {
+    it('prevents the transition if the promise resolve to `false`', function(
+      done
+    ) {
       const { run } = Ember;
       let didTransition = false;
       const waitForMe = function() {

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -632,6 +632,29 @@ describe('Integration: StepManagerComponent', function() {
           })
         );
       });
+
+      it('passes the direction when using transition-to-next or transition-to-previous', function() {
+        const beforeAction = td.function('before action');
+        this.on('beforeAction', beforeAction);
+
+        this.render(hbs`
+          {{#step-manager will-transition=(action 'beforeAction') as |w|}}
+            {{w.step}}
+            {{w.step}}
+
+            <button {{action w.transition-to-next}}>
+              Next
+            </button>
+          {{/step-manager}}
+        `);
+        click('button');
+
+        expect(beforeAction).to.be.calledWith(
+          matchContains({
+            direction: 'next'
+          })
+        );
+      });
     });
 
     it('can wait for a promise to resolve', function(done) {

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import RSVP from 'rsvp';
 import { expect } from 'chai';
 import { setupComponentTest } from 'ember-mocha';
 import { beforeEach, describe, it } from 'mocha';
@@ -6,6 +7,7 @@ import td from 'testdouble';
 import hbs from 'htmlbars-inline-precompile';
 import { initialize as initializeEmberHook, $hook } from 'ember-hook';
 import { click, findAll } from 'ember-native-dom-helpers';
+import wait from 'ember-test-helpers/wait';
 
 const { matchers: { anything: matchAnything, contains: matchContains } } = td;
 const { A } = Ember;
@@ -624,6 +626,86 @@ describe('Integration: StepManagerComponent', function() {
           })
         );
       });
+    });
+
+    it('can wait for a promise to resolve', function(done) {
+      const { run } = Ember;
+      let didTransition = false;
+      const waitForMe = function() {
+        return new RSVP.Promise(function(resolve) {
+          run.later(null, resolve, 500);
+        });
+      };
+      this.on('beforeAction', waitForMe);
+      this.on('afterTransition', () => (didTransition = true));
+
+      this.render(hbs`
+        {{#step-manager will-transition=(action 'beforeAction') did-transition=(action 'afterTransition') as |w|}}
+          {{#w.step name='first'}}
+            <div data-test={{hook 'first'}}></div>
+          {{/w.step}}
+
+          {{#w.step name='second'}}
+            <div data-test={{hook 'second'}}></div>
+          {{/w.step}}
+
+          <button {{action w.transition-to-next}}>
+            Next
+          </button>
+        {{/step-manager}}
+      `);
+
+      click('button');
+
+      expect(didTransition).to.equal(false);
+
+      return wait()
+        .then(() => {
+          expect(didTransition).to.equal(true);
+          expect($hook('first')).not.to.be.visible;
+          expect($hook('second')).to.be.visible;
+        })
+        .then(done, done);
+    });
+
+    it('prevents the transition if the promise reject', function(done) {
+      const { run } = Ember;
+      let didTransition = false;
+      const waitForMe = function() {
+        return new RSVP.Promise(function(resolve, reject) {
+          run.later(null, reject, 500);
+        });
+      };
+      this.on('beforeAction', waitForMe);
+      this.on('afterTransition', () => (didTransition = true));
+
+      this.render(hbs`
+        {{#step-manager will-transition=(action 'beforeAction') did-transition=(action 'afterTransition') as |w|}}
+          {{#w.step name='first'}}
+            <div data-test={{hook 'first'}}></div>
+          {{/w.step}}
+
+          {{#w.step name='second'}}
+            <div data-test={{hook 'second'}}></div>
+          {{/w.step}}
+
+          <button {{action w.transition-to-next}}>
+            Next
+          </button>
+        {{/step-manager}}
+      `);
+
+      click('button');
+
+      expect(didTransition).to.equal(false);
+
+      return wait()
+        .then(() => {
+          expect(didTransition).to.equal(false);
+          expect($hook('first')).to.be.visible;
+          expect($hook('second')).not.to.be.visible;
+        })
+        .then(done, done);
     });
 
     it('prevents the transition if it returns `false`', function() {


### PR DESCRIPTION
Everything is in the title. We can return a promise and the step-manager will wait for it to resolve before doing the transition and will not transition if the promise rejects.