### PR TITLE
Fix transition to previous

### DIFF
--- a/addon/-private/state-machine.js
+++ b/addon/-private/state-machine.js
@@ -74,13 +74,13 @@ export default EmberObject.extend({
     this.notifyPropertyChange('length');
   },
 
-  peek() {
+  pickNext() {
     const transitions = get(this, 'stepTransitions');
     const currentStep = get(this, 'currentStep');
     return transitions[currentStep];
   },
 
-  previous() {
+  pickPrevious() {
     let previous;
     const transitions = get(this, 'stepTransitions');
     const currentStep = get(this, 'currentStep');

--- a/addon/-private/state-machine.js
+++ b/addon/-private/state-machine.js
@@ -80,9 +80,19 @@ export default EmberObject.extend({
     return transitions[currentStep];
   },
 
-  next() {
-    const next = this.peek();
-    return this.activate(next);
+  previous() {
+    let previous;
+    const transitions = get(this, 'stepTransitions');
+    const currentStep = get(this, 'currentStep');
+
+    for (const k in transitions) {
+      if (transitions[k] === currentStep) {
+        previous = k;
+        break;
+      }
+    }
+
+    return previous;
   },
 
   activate(name) {

--- a/addon/components/step-manager.js
+++ b/addon/components/step-manager.js
@@ -224,7 +224,7 @@ export default Component.extend({
      * @public
      */
     'transition-to-next-step'(value) {
-      const to = get(this, 'transitions').peek();
+      const to = get(this, 'transitions').pickNext();
 
       this.send('transition-to-step', to, value);
     },
@@ -242,7 +242,7 @@ export default Component.extend({
      * @public
      */
     'transition-to-previous-step'(value) {
-      const to = get(this, 'transitions').previous();
+      const to = get(this, 'transitions').pickPrevious();
 
       this.send('transition-to-step', to, value);
     }

--- a/addon/components/step-manager.js
+++ b/addon/components/step-manager.js
@@ -242,11 +242,9 @@ export default Component.extend({
      * @public
      */
     'transition-to-previous-step'(value) {
-      const to = get(this, '_lastStep');
+      const to = get(this, 'transitions').previous();
 
-      if (to) {
-        this.send('transition-to-step', to, value);
-      }
+      this.send('transition-to-step', to, value);
     }
   }
 });

--- a/tests/dummy/app/application/template.hbs
+++ b/tests/dummy/app/application/template.hbs
@@ -14,6 +14,7 @@
       {{link-to 'Basic Usage' 'index' local-class="nav-item"}}
       {{link-to 'Named Steps' 'named-steps' local-class="nav-item"}}
       {{link-to 'Step Links' 'step-links' local-class="nav-item"}}
+      {{link-to 'Wizard example' 'wizard-example' local-class="nav-item"}}
     </nav>
 
   </div>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -27,6 +27,7 @@ const Router = EmberRouter.extend({
 Router.map(function() {
   this.route('named-steps');
   this.route('step-links');
+  this.route('wizard-example');
 });
 
 export default Router;

--- a/tests/dummy/app/wizard-example/route.js
+++ b/tests/dummy/app/wizard-example/route.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const { Route } = Ember;
+
+export default Route.extend({
+  titleToken: 'Wizard example'
+});

--- a/tests/dummy/app/wizard-example/template.hbs
+++ b/tests/dummy/app/wizard-example/template.hbs
@@ -1,0 +1,48 @@
+{{#usage-example title='Wizard example'}}
+  {{#block-slot 'rendered'}}
+    <p>
+      Here comes a wizard example usage for the ember-steps:
+    </p>
+
+    <ul>
+      <li>You can go to the next or previous step (as defined by the DOM implementation)</li>
+      <li>You can easily define a start and stop with specific actions</li>
+    </ul>
+
+    <hr />
+
+    {{!-- BEGIN-SNIPPET wizard-example --}}
+    {{#step-manager as |w|}}
+      {{#w.step name='a'}}
+        <h3>Step A</h3>
+      {{/w.step}}
+
+      {{#w.step name='b'}}
+        <h3>Step B</h3>
+      {{/w.step}}
+
+      {{#w.step name='c'}}
+        <h3>Step C</h3>
+      {{/w.step}}
+
+      <div>
+        {{#if (eq w.currentStep 'a')}}
+          <button>Cancel</button>
+        {{else}}
+          <button {{action w.transition-to-previous}}>Go to previous step</button>
+        {{/if}}
+        {{#if (eq w.currentStep 'c')}}
+          <button>Submit</button>
+        {{else}}
+          <button {{action w.transition-to-next}}>Go to next step</button>
+        {{/if}}
+      </div>
+
+    {{/step-manager}}
+    {{!-- END-SNIPPET --}}
+  {{/block-slot}}
+
+  {{#block-slot 'code-template'}}
+    {{code-snippet name='wizard-example.hbs'}}
+  {{/block-slot}}
+{{/usage-example}}

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -426,10 +426,16 @@ describe('Integration: StepManagerComponent', function() {
       expect($hook('second')).to.be.visible;
       expect($hook('third')).not.to.be.visible;
 
+      click('#next');
+
+      expect($hook('first')).not.to.be.visible;
+      expect($hook('second')).not.to.be.visible;
+      expect($hook('third')).to.be.visible;
+
       click('#previous');
 
-      expect($hook('first')).to.be.visible;
-      expect($hook('second')).not.to.be.visible;
+      expect($hook('first')).not.to.be.visible;
+      expect($hook('second')).to.be.visible;
       expect($hook('third')).not.to.be.visible;
     });
   });

--- a/tests/integration/step-manager/step-test.js
+++ b/tests/integration/step-manager/step-test.js
@@ -29,14 +29,11 @@ describe('Integration: StepManagerStepComponent', function() {
       expect(registerAction).to.be.called;
     });
 
-    it.skip(
-      'throws an error when not provided a registration action',
-      function() {
-        expect(() => {
-          this.render(hbs`{{step-manager/step}}`);
-        }).to.throw(Error);
-      }
-    );
+    it.skip('throws an error when not provided a registration action', function() {
+      expect(() => {
+        this.render(hbs`{{step-manager/step}}`);
+      }).to.throw(Error);
+    });
   });
 
   describe('the step name', function() {
@@ -85,16 +82,13 @@ describe('Integration: StepManagerStepComponent', function() {
       // at runtime. I eventually want to be able to error here because changes to
       // this value will not actually change the name of the step and could get
       // the user in trouble.
-      it.skip(
-        'errors when given a value from the `readonly` helper',
-        function() {
-          expect(() => {
-            this.render(hbs`
-            {{step-manager/step name=(readonly name) register-step=(action 'register')}}
-          `);
-          }).to.throw(StepNameError, /Name must be an immutable string/);
-        }
-      );
+      it.skip('errors when given a value from the `readonly` helper', function() {
+        expect(() => {
+          this.render(hbs`
+          {{step-manager/step name=(readonly name) register-step=(action 'register')}}
+        `);
+        }).to.throw(StepNameError, /Name must be an immutable string/);
+      });
 
       it.skip('errors when given a dynamic property directly', function() {
         expect(() => {

--- a/tests/unit/utils/state-machine-test.js
+++ b/tests/unit/utils/state-machine-test.js
@@ -20,25 +20,25 @@ describe('Step Transition State Machine', function() {
     });
   });
 
-  describe('#peek', function() {
+  describe('#pickNext', function() {
     it('can get the next step without advancing', function() {
       const m = new StateMachine();
       m.addStep('foo');
       m.addStep('bar');
 
-      expect(m.peek()).to.equal('bar');
+      expect(m.pickNext()).to.equal('bar');
       expect(m.get('currentStep')).to.equal('foo');
     });
   });
 
-  describe('#previous', function() {
+  describe('#pickPrevious', function() {
     it('can get the previous step without advancing', function() {
       const m = new StateMachine();
       m.addStep('foo');
       m.addStep('bar');
       m.addStep('baz');
 
-      expect(m.previous()).to.equal('baz');
+      expect(m.pickPrevious()).to.equal('baz');
       expect(m.get('currentStep')).to.equal('foo');
     });
   });

--- a/tests/unit/utils/state-machine-test.js
+++ b/tests/unit/utils/state-machine-test.js
@@ -31,16 +31,15 @@ describe('Step Transition State Machine', function() {
     });
   });
 
-  describe('#next', function() {
-    it('can transition to the next step', function() {
+  describe('#previous', function() {
+    it('can get the previous step without advancing', function() {
       const m = new StateMachine();
       m.addStep('foo');
       m.addStep('bar');
       m.addStep('baz');
 
-      expect(m.next()).to.equal('bar');
-      expect(m.next()).to.equal('baz');
-      expect(m.next()).to.equal('foo');
+      expect(m.previous()).to.equal('baz');
+      expect(m.get('currentStep')).to.equal('foo');
     });
   });
 


### PR DESCRIPTION
Hi,
Here is a fix for the PR about the `transition-to-previous`. The use case is the following :
- Having 3 steps
- You click next on the two first steps
- You then click previous
- You should be taken back to the second step

With the previous version you were either :
- Going to the first step if you didn't declare a mutation of `currentStep`
- Going to the actual current step if you declare a mutation of `currentStep`

I also included an example of a wizard (which was a good way to test the different use cases as well).