### PR TITLE
Step manager now handles removal

### DIFF
--- a/addon/-private/state-machine/-base.ts
+++ b/addon/-private/state-machine/-base.ts
@@ -1,10 +1,15 @@
 import Ember from 'ember';
-import EmberObject, { set, get } from '@ember/object';
+import EmberObject, {
+  set,
+  get,
+  setProperties,
+  getProperties
+} from '@ember/object';
 import { isPresent } from '@ember/utils';
 import { A } from '@ember/array';
 import { readOnly } from '@ember-decorators/object/computed';
 import { assert } from '@ember/debug';
-
+import { scheduleOnce, bind } from '@ember/runloop';
 /**
  * Keeps track of the order of the steps in the step manager, as well as
  * the current step.
@@ -18,7 +23,7 @@ export default abstract class StateMachine extends EmberObject {
    * @property {A} stepTransitions
    * @private
    */
-  stepTransitions: Ember.MutableArray<string> = A();
+  stepTransitions: Ember.MutableArray<any> = A();
 
   /**
    * @property {string} firstStep
@@ -38,6 +43,10 @@ export default abstract class StateMachine extends EmberObject {
    */
   currentStep: string;
 
+  stepsToRemove: Ember.NativeArray<any> = A();
+
+  stepsToAdd: Ember.NativeArray<any> = A();
+
   constructor(initialStep: string) {
     super();
 
@@ -47,24 +56,126 @@ export default abstract class StateMachine extends EmberObject {
   }
 
   addStep(this: StateMachine, name: string) {
-    if (this.stepTransitions.includes(name)) {
+    if (this.stepsToAdd.includes(name)) {
       return;
     }
 
-    // Set the first step, if it hasn't been yet
-    if (!get(this, 'firstStep')) {
-      set(this, 'firstStep', name);
+    this.stepsToAdd.push(name);
+    return bind(
+      this,
+      scheduleOnce,
+      'afterRender',
+      this,
+      this.flushAdditionQueue
+    )();
+  }
+
+  removeStep(this: StateMachine, name: string) {
+    if (this.stepsToRemove.includes(name)) {
+      return;
     }
 
-    this.stepTransitions.pushObject(name);
+    this.stepsToRemove.push(name);
+    return bind(this, scheduleOnce, 'render', this, this.flushRemoveQueue)();
+  }
 
-    // Set the current step, if it hasn't been yet
-    if (!get(this, 'currentStep')) {
-      set(this, 'currentStep', name);
+  flushAdditionQueue(this: StateMachine) {
+    let { firstStep, currentStep, stepsToAdd, stepTransitions } = getProperties(
+      this,
+      'firstStep',
+      'currentStep',
+      'stepsToAdd',
+      'stepTransitions'
+    );
+    let lastStep;
+
+    A(stepsToAdd)
+      // don't add steps that are already included
+      .filter(name => !this.stepTransitions.includes(name))
+      .forEach(name => {
+        // Set the first step, if it hasn't been yet
+        if (!firstStep) {
+          firstStep = name;
+        }
+
+        this.stepTransitions.pushObject(name);
+
+        // Set the current step, if it hasn't been yet
+        if (!currentStep) {
+          currentStep = name;
+        }
+
+        // Set the last step to this new one
+        lastStep = name;
+      });
+
+    setProperties(this, {
+      firstStep,
+      currentStep,
+      lastStep,
+      stepsToAdd: A()
+    });
+  }
+
+  flushRemoveQueue(this: StateMachine) {
+    let {
+      firstStep,
+      currentStep,
+      lastStep,
+      stepsToRemove,
+      stepsToAdd,
+      stepTransitions
+    } = getProperties(
+      this,
+      'firstStep',
+      'currentStep',
+      'lastStep',
+      'stepsToRemove',
+      'stepsToAdd',
+      'stepTransitions'
+    );
+
+    //don't remove steps that are to be added
+    stepsToRemove = A(
+      stepsToRemove.filter(stepToRemove => !stepsToAdd.includes(stepToRemove))
+    );
+
+    if (get(stepsToRemove, 'length') === get(stepTransitions, 'length')) {
+      setProperties(this, {
+        firstStep: null,
+        currentStep: null,
+        lastStep: null,
+        stepsToRemove: A(),
+        stepTransitions: A()
+      });
+
+      return;
     }
 
-    // Set the last step to this new one
-    set(this, 'lastStep', name);
+    A(stepsToRemove).forEach(name => {
+      this.stepTransitions.removeObject(name);
+
+      if (get(this, 'firstStep') === name) {
+        firstStep = this.stepTransitions.objectAt(0);
+      }
+
+      if (get(this, 'currentStep') === name) {
+        const nameIdx = this.stepTransitions.indexOf(name);
+        currentStep = this.stepTransitions.objectAt(nameIdx);
+      }
+
+      if (get(this, 'lastStep') === name) {
+        const len = get(stepTransitions, 'length');
+        lastStep = this.stepTransitions.objectAt(len - 1);
+      }
+    });
+
+    setProperties(this, {
+      firstStep,
+      currentStep,
+      lastStep,
+      stepsToRemove: A()
+    });
   }
 
   abstract pickNext(currentStep?: string): string;

--- a/addon/components/step-manager.ts
+++ b/addon/components/step-manager.ts
@@ -155,9 +155,16 @@ export default class StepManagerComponent extends TaglessComponent {
 
       stepComponent.transitions = transitions;
 
-      schedule('actions', () => {
-        transitions.addStep(name);
-      });
+      transitions.addStep(name);
+    },
+
+    removeStepComponent(
+      this: StepManagerComponent,
+      stepComponent: StepComponent
+    ) {
+      const name = get(stepComponent, 'name');
+
+      this.transitions.removeStep(name);
     },
 
     /**

--- a/addon/components/step-manager/step.ts
+++ b/addon/components/step-manager/step.ts
@@ -45,6 +45,11 @@ export default class StepComponent extends TaglessComponent {
     this['register-step'](this);
   }
 
+  willDestroyElement() {
+    this.removeObserver('name', this, failOnNameChange);
+    this['remove-step'](this);
+  }
+
   /**
    * Whether this state is currently the active one
    * @property {boolean} isActive

--- a/addon/templates/components/step-manager.hbs
+++ b/addon/templates/components/step-manager.hbs
@@ -1,6 +1,7 @@
 {{yield (hash
     step=(component 'step-manager/step'
       register-step=(action 'registerStepComponent')
+      remove-step=(action 'removeStepComponent')
       currentStep=transitions.currentStep
       transitions=transitions
     )

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -558,5 +558,78 @@ module('step-manager', function(hooks) {
       assert.dom(hook('step', { name: 'baz' })).doesNotExist();
       assert.dom(hook('steps')).hasText('foo');
     });
+
+    test('allows for removing steps after initial render', async function(assert) {
+      this.set('data', A([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]));
+
+      await render(hbs`
+        {{#step-manager linear=true as |w|}}
+          <div data-test={{hook 'steps'}}>
+            {{#each data as |item|}}
+              {{#w.step name=item.name}}
+                <div data-test={{hook 'step' name=item.name}}>
+                  {{item.name}}
+                </div>
+              {{/w.step}}
+            {{/each}}
+          </div>
+
+          <button data-test={{hook 'next'}} {{action w.transition-to-next}}>
+            Next
+          </button>
+          <button data-test={{hook 'back'}} {{action w.transition-to-previous}}>
+            back
+          </button>
+        {{/step-manager}}
+      `);
+
+      this.set('data', A([{ name: 'foo' }, { name: 'baz' }]));
+
+      assert.dom(hook('step', { name: 'foo' })).exists();
+      await click(hook('next'));
+      assert.dom(hook('step', { name: 'baz' })).exists();
+      await click(hook('back'));
+      assert.dom(hook('step', { name: 'foo' })).exists();
+    });
+
+    test('removal of steps works for circular step managers', async function(assert) {
+      this.set(
+        'data',
+        A([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }, { name: '4' }])
+      );
+
+      await render(hbs`
+        {{#step-manager linear=false as |w|}}
+          <div data-test={{hook 'steps'}}>
+            {{#each data as |item|}}
+              {{#w.step name=item.name}}
+                <div data-test={{hook 'step' name=item.name}}>
+                  {{item.name}}
+                </div>
+              {{/w.step}}
+            {{/each}}
+          </div>
+
+          <button data-test={{hook 'next'}} {{action w.transition-to-next}}>
+            Next
+          </button>
+          <button data-test={{hook 'back'}} {{action w.transition-to-previous}}>
+            back
+          </button>
+        {{/step-manager}}
+      `);
+
+      this.set('data', A([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]));
+
+      assert.dom(hook('step', { name: 'foo' })).exists();
+      await click(hook('next'));
+      assert.dom(hook('step', { name: 'bar' })).exists();
+      await click(hook('next'));
+      assert.dom(hook('step', { name: 'baz' })).exists();
+      await click(hook('next'));
+      assert.dom(hook('step', { name: 'foo' })).exists();
+      await click(hook('back'));
+      assert.dom(hook('step', { name: 'baz' })).exists();
+    });
   });
 });

--- a/tests/integration/step-manager/step-test.js
+++ b/tests/integration/step-manager/step-test.js
@@ -12,6 +12,7 @@ module('step-manger/step', function(hooks) {
 
   hooks.beforeEach(function() {
     this.set('register', function() {});
+    this.set('remove', function() {});
   });
 
   module('registering with the rendering context', function() {
@@ -20,7 +21,7 @@ module('step-manger/step', function(hooks) {
       this.set('register', registerAction);
 
       await render(hbs`
-        {{step-manager/step name='foo' register-step=(action register)}}
+        {{step-manager/step name='foo' register-step=(action register) remove-step=(action remove)}}
       `);
 
       assert.wasCalled(registerAction);
@@ -32,7 +33,7 @@ module('step-manger/step', function(hooks) {
       this.set('name', 'foo');
 
       await render(hbs`
-        {{step-manager/step name=name register-step=(action register)}}
+        {{step-manager/step name=name register-step=(action register) remove-step=(action remove)}}
       `);
 
       assert.expectAssertion(() => {
@@ -44,7 +45,7 @@ module('step-manger/step', function(hooks) {
   module('rendering', function() {
     test('renders block content when visible', async function(assert) {
       await render(hbs`
-        {{#step-manager/step name='foo' currentStep='foo' register-step=(action register)}}
+        {{#step-manager/step name='foo' currentStep='foo' register-step=(action register) remove-step=(action remove)}}
           <div data-test={{hook 'step'}}>
             Foo
           </div>
@@ -57,7 +58,7 @@ module('step-manger/step', function(hooks) {
     module('when inactive', function() {
       test('is hidden when no alternate state is provided', async function(assert) {
         await render(hbs`
-          {{#step-manager/step name='foo' register-step=(action register)}}
+          {{#step-manager/step name='foo' register-step=(action register) remove-step=(action remove)}}
             <div data-test={{hook 'step'}}>
               Active Content
             </div>
@@ -70,7 +71,7 @@ module('step-manger/step', function(hooks) {
       test('renders the inverse block if provided', async function(assert) {
         await render(hbs`
           <div data-test={{hook 'step'}}>
-            {{#step-manager/step name='foo' register-step=(action register)}}
+            {{#step-manager/step name='foo' register-step=(action register) remove-step=(action remove)}}
               Active Content
             {{else}}
               Inactive Content
@@ -86,7 +87,7 @@ module('step-manger/step', function(hooks) {
   module('programmatically controlling visibility', function() {
     test('is visible when active', async function(assert) {
       await render(hbs`
-        {{#step-manager/step name='foo' currentStep='foo' register-step=(action register)}}
+        {{#step-manager/step name='foo' currentStep='foo' register-step=(action register) remove-step=(action remove)}}
           <div data-test={{hook 'step'}}></div>
         {{/step-manager/step}}
       `);
@@ -96,7 +97,7 @@ module('step-manger/step', function(hooks) {
 
     test('is invisible when not active', async function(assert) {
       await render(hbs`
-        {{#step-manager/step name='foo' currentStep='bar' register-step=(action register)}}
+        {{#step-manager/step name='foo' currentStep='bar' register-step=(action register) remove-step=(action remove)}}
           <div data-test={{hook 'step'}}></div>
         {{/step-manager/step}}
       `);


### PR DESCRIPTION
When steps are destroyed, the willDestroy element hook now sends an action to remove a step. This removal does not happen immediately, instead it is placed in a queue to happen after render.
When steps are added, the addStep function is now modified to put steps to add in a queue as well, which will be acted upon during render
Then, when the render queue happens, the steps to add queue is flushed. First, we do not add steps that already exist in the transition. Then we proceed with the normal way to add steps. First, if there is no first step, it is set. Then, the current step is set if it's not already. Finally, the last step added is always the last step.
For the removal queue, its very similar. Steps that are to be added are not removed. If all the steps are to be removed, then we just reset the transitions and first/current/last steps. Otherwise we follow a similar procedure to removing steps. If the first/current/last step is removed, then new ones are found. That is it.