### PR TITLE
Removed the queue system, got tests to pass using removeAt and push

### DIFF
--- a/addon/-private/state-machine/-base.ts
+++ b/addon/-private/state-machine/-base.ts
@@ -62,7 +62,7 @@ export default abstract class StateMachine extends EmberObject {
 
     this.stepTransitions.pushObject(name);
 
-    return bind(
+    bind(
       this,
       scheduleOnce,
       'actions',
@@ -78,7 +78,7 @@ export default abstract class StateMachine extends EmberObject {
 
     this.stepTransitions.removeObject(name);
 
-    return bind(
+    bind(
       this,
       scheduleOnce,
       'actions',

--- a/addon/-private/state-machine/-base.ts
+++ b/addon/-private/state-machine/-base.ts
@@ -56,123 +56,61 @@ export default abstract class StateMachine extends EmberObject {
   }
 
   addStep(this: StateMachine, name: string) {
-    if (this.stepsToAdd.includes(name)) {
+    if (this.stepTransitions.includes(name)) {
       return;
     }
 
-    this.stepsToAdd.push(name);
+    this.stepTransitions.pushObject(name);
+
     return bind(
       this,
       scheduleOnce,
-      'afterRender',
+      'actions',
       this,
-      this.flushAdditionQueue
+      this.updateFirstCurrentAndLastSteps
     )();
   }
 
   removeStep(this: StateMachine, name: string) {
-    if (this.stepsToRemove.includes(name)) {
+    if (!this.stepTransitions.includes(name)) {
       return;
     }
 
-    this.stepsToRemove.push(name);
-    return bind(this, scheduleOnce, 'render', this, this.flushRemoveQueue)();
+    this.stepTransitions.removeObject(name);
+
+    return bind(
+      this,
+      scheduleOnce,
+      'actions',
+      this,
+      this.updateFirstCurrentAndLastSteps
+    )();
   }
 
-  flushAdditionQueue(this: StateMachine) {
-    let { firstStep, currentStep, stepsToAdd, stepTransitions } = getProperties(
-      this,
-      'firstStep',
-      'currentStep',
-      'stepsToAdd',
-      'stepTransitions'
-    );
-    let lastStep;
+  updateFirstCurrentAndLastSteps(this: StateMachine) {
+    const len = get(this.stepTransitions, 'length');
+    let nameIdx = this.stepTransitions.indexOf(this.currentStep);
 
-    A(stepsToAdd)
-      .filter(name => !this.stepTransitions.includes(name))
-      .forEach(name => {
-        // Set the first step, if it hasn't been yet
-        if (!firstStep) {
-          firstStep = name;
-        }
-
-        this.stepTransitions.pushObject(name);
-
-        if (!currentStep) {
-          currentStep = name;
-        }
-
-        lastStep = name;
-      });
-
-    setProperties(this, {
-      firstStep,
-      currentStep,
-      lastStep
-    });
-    stepsToAdd.clear();
-  }
-
-  flushRemoveQueue(this: StateMachine) {
-    let {
-      firstStep,
-      currentStep,
-      lastStep,
-      stepsToRemove,
-      stepsToAdd,
-      stepTransitions
-    } = getProperties(
-      this,
-      'firstStep',
-      'currentStep',
-      'lastStep',
-      'stepsToRemove',
-      'stepsToAdd',
-      'stepTransitions'
-    );
-
-    //don't remove steps that are to be added
-    stepsToRemove = A(
-      stepsToRemove.filter(stepToRemove => !stepsToAdd.includes(stepToRemove))
-    );
-
-    if (get(stepsToRemove, 'length') === get(stepTransitions, 'length')) {
+    if (len === 0) {
       setProperties(this, {
         firstStep: null,
         currentStep: null,
         lastStep: null
       });
 
-      stepsToRemove.clear();
-      stepTransitions.clear();
+      this.stepTransitions.clear();
       return;
     }
 
-    A(stepsToRemove).forEach(name => {
-      this.stepTransitions.removeObject(name);
-
-      if (get(this, 'firstStep') === name) {
-        firstStep = this.stepTransitions.objectAt(0);
-      }
-
-      if (get(this, 'currentStep') === name) {
-        const nameIdx = this.stepTransitions.indexOf(name);
-        currentStep = this.stepTransitions.objectAt(nameIdx);
-      }
-
-      if (get(this, 'lastStep') === name) {
-        const len = get(stepTransitions, 'length');
-        lastStep = this.stepTransitions.objectAt(len - 1);
-      }
-    });
+    if (nameIdx === -1) {
+      nameIdx = 0;
+    }
 
     setProperties(this, {
-      firstStep,
-      currentStep,
-      lastStep
+      firstStep: this.stepTransitions.objectAt(0),
+      currentStep: this.stepTransitions.objectAt(nameIdx),
+      lastStep: this.stepTransitions.objectAt(len - 1)
     });
-    stepsToRemove.clear();
   }
 
   abstract pickNext(currentStep?: string): string;

--- a/addon/components/step-manager.ts
+++ b/addon/components/step-manager.ts
@@ -154,15 +154,23 @@ export default class StepManagerComponent extends TaglessComponent {
       const transitions = this.transitions;
 
       stepComponent.transitions = transitions;
-      transitions.addStep(name);
+      schedule('render', transitions, transitions.addStep, name);
     },
 
+    /**
+     * Remove a step from the manager.
+     * 
+     * Removes a step by name. It's scheduled after the addition to avoid
+     * removing a step after immediately adding it.
+     */
     removeStepComponent(
       this: StepManagerComponent,
       stepComponent: StepComponent
     ) {
       const name = get(stepComponent, 'name');
-      this.transitions.removeStep(name)
+      const transitions = this.transitions;
+
+      schedule('actions', transitions, transitions.removeStep, name);
     },
 
     /**

--- a/addon/components/step-manager.ts
+++ b/addon/components/step-manager.ts
@@ -95,12 +95,12 @@ export default class StepManagerComponent extends TaglessComponent {
     set(this, 'transitions', new StateMachine(initialStep));
   }
 
-  @computed('transitions.{currentStep,length}')
+  @computed('transitions.currentStep')
   get hasNextStep() {
     return isPresent(this.transitions.pickNext());
   }
 
-  @computed('transitions.{currentStep,length}')
+  @computed('transitions.currentStep')
   get hasPreviousStep() {
     return isPresent(this.transitions.pickPrevious());
   }
@@ -154,7 +154,6 @@ export default class StepManagerComponent extends TaglessComponent {
       const transitions = this.transitions;
 
       stepComponent.transitions = transitions;
-
       transitions.addStep(name);
     },
 
@@ -163,8 +162,7 @@ export default class StepManagerComponent extends TaglessComponent {
       stepComponent: StepComponent
     ) {
       const name = get(stepComponent, 'name');
-
-      this.transitions.removeStep(name);
+      this.transitions.removeStep(name)
     },
 
     /**

--- a/addon/components/step-manager/step.ts
+++ b/addon/components/step-manager/step.ts
@@ -47,6 +47,7 @@ export default class StepComponent extends TaglessComponent {
 
   willDestroyElement() {
     this.removeObserver('name', this, failOnNameChange);
+
     this['remove-step'](this);
   }
 

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -536,7 +536,7 @@ module('step-manager', function(hooks) {
       assert.dom(hook('step', { name: 'foo' })).doesNotExist();
       assert.dom(hook('step', { name: 'bar' })).exists();
 
-      this.set('data', A([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]));
+      this.data.pushObject({ name: 'baz' });
 
       assert.dom(hook('step', { name: 'foo' })).doesNotExist();
       assert.dom(hook('step', { name: 'bar' })).exists();
@@ -587,7 +587,7 @@ module('step-manager', function(hooks) {
         {{/step-manager}}
       `);
 
-      this.set('data', A([{ name: 'foo' }, { name: 'baz' }]));
+      this.data.removeAt(1);
 
       assert.dom(hook('step', { name: 'foo' })).exists();
       await click(hook('next'));
@@ -623,7 +623,7 @@ module('step-manager', function(hooks) {
         {{/step-manager}}
       `);
 
-      this.set('data', A([{ name: 'foo' }, { name: 'bar' }, { name: 'baz' }]));
+      this.data.removeAt(3);
 
       assert.dom(hook('step', { name: 'foo' })).exists();
       await click(hook('next'));


### PR DESCRIPTION
When the user calls
this.set('data', [ ...data]);
this.set('data', [ ...data, newStep]);

This causes the willDestroyElement hook to be called on every element.
However if the user uses pushObject, then willDestoryElement isn't called.

The same is true for using removeAt rather deletion by setting the array again.