### PR TITLE
Introduce `StepNode` objects

### DIFF
--- a/addon/-private/state-machine/-base.ts
+++ b/addon/-private/state-machine/-base.ts
@@ -6,14 +6,7 @@ import { readOnly } from '@ember-decorators/object/computed';
 import { assert } from '@ember/debug';
 
 import { StepName } from '../types';
-
-class StepNode {
-  name: StepName;
-
-  constructor(name: StepName) {
-    this.name = name;
-  }
-}
+import StepNode from '../step-node';
 
 /**
  * Keeps track of the order of the steps in the step manager, as well as
@@ -41,7 +34,7 @@ export default abstract class BaseStateMachine extends EmberObject {
   }
 
   addStep(name: StepName) {
-    const node = new StepNode(name);
+    const node = new StepNode(this, name);
     this.stepTransitions.pushObject(node);
 
     if (!this.currentStep) {

--- a/addon/-private/state-machine/-base.ts
+++ b/addon/-private/state-machine/-base.ts
@@ -33,8 +33,8 @@ export default abstract class BaseStateMachine extends EmberObject {
     }
   }
 
-  addStep(name: StepName) {
-    const node = new StepNode(this, name);
+  addStep(name: StepName, context: any) {
+    const node = new StepNode(this, name, context);
     this.stepTransitions.pushObject(node);
 
     if (!this.currentStep) {
@@ -50,6 +50,14 @@ export default abstract class BaseStateMachine extends EmberObject {
     const index = this.stepTransitions.indexOf(node!);
 
     this.stepTransitions.removeAt(index);
+  }
+
+  updateContext(name: StepName, context: any) {
+    const node = this.stepTransitions.find(node => node.name === name);
+
+    assert(`"${name}" does not match an existing step`, !!node);
+
+    set(node!, 'context', context);
   }
 
   abstract pickNext(currentStep?: StepName): StepName | undefined;

--- a/addon/-private/state-machine/circular.ts
+++ b/addon/-private/state-machine/circular.ts
@@ -12,25 +12,41 @@ import { get } from '@ember/object';
  */
 export default class CircularStateMachine extends BaseStateMachine {
   pickNext(currentStep = this.currentStep) {
-    const currentIndex = this.stepTransitions.indexOf(currentStep);
+    const currentIndex = this.stepTransitions
+      .map(node => node.name)
+      .indexOf(currentStep);
     const nextValue = this.stepTransitions.objectAt(currentIndex + 1);
 
     if (nextValue) {
-      return nextValue;
+      return nextValue.name;
     }
 
-    return this.stepTransitions.objectAt(0);
+    const firstObject = this.stepTransitions.objectAt(0);
+
+    if (firstObject) {
+      return firstObject.name;
+    }
+
+    return undefined;
   }
 
   pickPrevious(currentStep = this.currentStep) {
-    const currentIndex = this.stepTransitions.indexOf(currentStep);
+    const currentIndex = this.stepTransitions
+      .map(node => node.name)
+      .indexOf(currentStep);
     const previousValue = this.stepTransitions.objectAt(currentIndex - 1);
 
     if (previousValue) {
-      return previousValue;
+      return previousValue.name;
     }
 
     const lastIndex = get(this, 'length') - 1;
-    return this.stepTransitions.objectAt(lastIndex);
+    const lastObject = this.stepTransitions.objectAt(lastIndex);
+
+    if (lastObject) {
+      return lastObject.name;
+    }
+
+    return undefined;
   }
 }

--- a/addon/-private/state-machine/linear.ts
+++ b/addon/-private/state-machine/linear.ts
@@ -11,14 +11,28 @@ import BaseStateMachine from './-base';
  */
 export default class LinearStateMachine extends BaseStateMachine {
   pickNext(currentStep = this.currentStep) {
-    const currentIndex = this.stepTransitions.indexOf(currentStep);
+    const currentIndex = this.stepTransitions
+      .map(node => node.name)
+      .indexOf(currentStep);
+    const currentNode = this.stepTransitions.objectAt(currentIndex + 1);
 
-    return this.stepTransitions.objectAt(currentIndex + 1);
+    if (currentNode) {
+      return currentNode.name;
+    }
+
+    return undefined;
   }
 
   pickPrevious(currentStep = this.currentStep) {
-    const currentIndex = this.stepTransitions.indexOf(currentStep);
+    const currentIndex = this.stepTransitions
+      .map(node => node.name)
+      .indexOf(currentStep);
+    const currentNode = this.stepTransitions.objectAt(currentIndex - 1);
 
-    return this.stepTransitions.objectAt(currentIndex - 1);
+    if (currentNode) {
+      return currentNode.name;
+    }
+
+    return undefined;
   }
 }

--- a/addon/-private/step-node.ts
+++ b/addon/-private/step-node.ts
@@ -6,9 +6,11 @@ import StateMachine from './state-machine/-base';
 
 export default class StepNode {
   name: StepName;
+  context: any;
 
-  constructor(private sm: StateMachine, name: StepName) {
+  constructor(private sm: StateMachine, name: StepName, context: any) {
     this.name = name;
+    this.context = context;
   }
 
   get hasNext(): boolean {

--- a/addon/-private/step-node.ts
+++ b/addon/-private/step-node.ts
@@ -1,0 +1,25 @@
+import { get } from '@ember/object';
+import { isPresent } from '@ember/utils';
+
+import { StepName } from './types';
+import StateMachine from './state-machine/-base';
+
+export default class StepNode {
+  name: StepName;
+
+  constructor(private sm: StateMachine, name: StepName) {
+    this.name = name;
+  }
+
+  get hasNext(): boolean {
+    return isPresent(this.sm.pickNext(this.name));
+  }
+
+  get hasPrevious(): boolean {
+    return isPresent(this.sm.pickPrevious(this.name));
+  }
+
+  get isActive(): boolean {
+    return get(this.sm, 'currentStep') === this.name;
+  }
+}

--- a/addon/-private/step-node.ts
+++ b/addon/-private/step-node.ts
@@ -1,14 +1,18 @@
-import { get } from '@ember/object';
+import EmberObject, { get } from '@ember/object';
 import { isPresent } from '@ember/utils';
+
+import { computed } from '@ember-decorators/object';
 
 import { StepName } from './types';
 import StateMachine from './state-machine/-base';
 
-export default class StepNode {
+export default class StepNode extends EmberObject {
   name: StepName;
   context: any;
 
   constructor(private sm: StateMachine, name: StepName, context: any) {
+    super();
+
     this.name = name;
     this.context = context;
   }
@@ -21,6 +25,7 @@ export default class StepNode {
     return isPresent(this.sm.pickPrevious(this.name));
   }
 
+  @computed('sm.currentStep')
   get isActive(): boolean {
     return get(this.sm, 'currentStep') === this.name;
   }

--- a/addon/components/-tagless.ts
+++ b/addon/components/-tagless.ts
@@ -1,5 +1,0 @@
-import Component from '@ember/component';
-
-export default class TaglessComponent extends Component.extend({
-  tagName: ''
-}) {}

--- a/addon/components/step-manager.ts
+++ b/addon/components/step-manager.ts
@@ -1,4 +1,4 @@
-import TaglessComponent from './-tagless';
+import Component from '@ember/component';
 // @ts-ignore: Ignore import of compiled template
 import layout from '../templates/components/step-manager';
 import { get, set } from '@ember/object';
@@ -6,6 +6,7 @@ import { isEmpty, isPresent } from '@ember/utils';
 import { schedule } from '@ember/runloop';
 import { assert } from '@ember/debug';
 import { action, computed } from '@ember-decorators/object';
+import { tagName } from '@ember-decorators/component';
 
 import BaseStateMachine from '../-private/state-machine/-base';
 import CircularStateMachine from '../-private/state-machine/circular';
@@ -44,7 +45,8 @@ import StepComponent from './step-manager/step';
  * @public
  * @hide
  */
-export default class StepManagerComponent extends TaglessComponent {
+@tagName('')
+export default class StepManagerComponent extends Component {
   layout = layout;
 
   /* Optionally can be provided to override the initial step to render */

--- a/addon/components/step-manager.ts
+++ b/addon/components/step-manager.ts
@@ -13,6 +13,7 @@ import CircularStateMachine from '../-private/state-machine/circular';
 import LinearStateMachine from '../-private/state-machine/linear';
 
 import { StepName } from '../-private/types';
+import StepNode from '../-private/step-node';
 import StepComponent from './step-manager/step';
 
 /**
@@ -140,14 +141,16 @@ export default class StepManagerComponent extends Component {
   }
 
   @action
-  transitionTo(to: StepName) {
+  transitionTo(to: StepName | StepNode) {
+    const destination = to instanceof StepNode ? to.name : to;
+
     // If `currentStep` is present, it's probably something the user wants
     // two-way-bound with the new value
     if (!isEmpty(this.currentStep)) {
-      set(this, 'currentStep', to);
+      set(this, 'currentStep', destination);
     }
 
-    this.transitions.activate(to);
+    this.transitions.activate(destination);
   }
 
   @action

--- a/addon/components/step-manager.ts
+++ b/addon/components/step-manager.ts
@@ -113,12 +113,13 @@ export default class StepManagerComponent extends Component {
   @action
   registerStepComponent(stepComponent: StepComponent) {
     const name = get(stepComponent, 'name');
+    const context = get(stepComponent, 'context');
     const transitions = this.transitions;
 
     stepComponent.transitions = transitions;
 
     schedule('actions', () => {
-      transitions.addStep(name);
+      transitions.addStep(name, context);
     });
   }
 
@@ -129,6 +130,13 @@ export default class StepManagerComponent extends Component {
     schedule('actions', () => {
       this.transitions.removeStep(name);
     });
+  }
+
+  @action
+  updateStepContext(stepComponent: StepComponent, context: any) {
+    const name = get(stepComponent, 'name');
+
+    this.transitions.updateContext(name, context);
   }
 
   @action

--- a/addon/components/step-manager/step.ts
+++ b/addon/components/step-manager/step.ts
@@ -19,6 +19,7 @@ export default class StepComponent extends Component {
   layout = layout;
 
   name!: StepName;
+  context!: any;
 
   currentStep!: StepName;
 
@@ -26,6 +27,7 @@ export default class StepComponent extends Component {
 
   'register-step'!: (stepComponent: StepComponent) => void;
   'remove-step'!: (stepComponent: StepComponent) => void;
+  'update-context'!: (stepComponent: StepComponent, context: any) => void;
 
   constructor() {
     super(...arguments);
@@ -42,13 +44,21 @@ export default class StepComponent extends Component {
       set(this, 'name', name);
     }
     this.addObserver('name', this, failOnNameChange);
+    this.addObserver('context', this, this.updateContext);
 
     this['register-step'](this);
   }
 
   willDestroyElement() {
     this.removeObserver('name', this, failOnNameChange);
+    this.removeObserver('context', this, this.updateContext);
     this['remove-step'](this);
+  }
+
+  private updateContext() {
+    const context = get(this, 'context');
+
+    this['update-context'](this, context);
   }
 
   /**

--- a/addon/components/step-manager/step.ts
+++ b/addon/components/step-manager/step.ts
@@ -1,10 +1,11 @@
-import TaglessComponent from '../-tagless';
+import Component from '@ember/component';
 // @ts-ignore: Ignore import of compiled template
 import layout from '../../templates/components/step-manager/step';
 import { get, set } from '@ember/object';
 import { isEmpty, isPresent } from '@ember/utils';
 import { assert } from '@ember/debug';
 import { computed } from '@ember-decorators/object';
+import { tagName } from '@ember-decorators/component';
 
 import StateMachine from '../../-private/state-machine/-base';
 import { StepName } from '../../-private/types';
@@ -13,7 +14,8 @@ function failOnNameChange() {
   assert('The `name` property should never change');
 }
 
-export default class StepComponent extends TaglessComponent {
+@tagName('')
+export default class StepComponent extends Component {
   layout = layout;
 
   name!: StepName;

--- a/addon/templates/components/step-manager.hbs
+++ b/addon/templates/components/step-manager.hbs
@@ -2,6 +2,7 @@
     step=(component 'step-manager/step'
       register-step=(action 'registerStepComponent')
       remove-step=(action 'removeStepComponent')
+      update-context=(action 'updateStepContext')
       currentStep=transitions.currentStep
       transitions=transitions
     )

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "typescript-eslint-parser": "^15.0.0"
   },
   "dependencies": {
+    "@ember-decorators/component": "^2.1.0",
     "@ember-decorators/object": "^2.1.0",
     "ember-cli-babel": "^6.12.0",
     "ember-cli-htmlbars": "^2.0.3"

--- a/tests/dummy/app/docs/cookbook/wizard/demo-wizard-with-progress-indicator/template.hbs
+++ b/tests/dummy/app/docs/cookbook/wizard/demo-wizard-with-progress-indicator/template.hbs
@@ -21,7 +21,7 @@
           {{#each w.steps as |step|}}
             <button
                 local-class="progress-dot"
-                aria-pressed={{eq w.currentStep step}}
+                aria-pressed={{step.isActive}}
                 {{action w.transition-to step}}>
             </button>
           {{/each}}

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -199,68 +199,136 @@ module('step-manager', function(hooks) {
     });
 
     module('exposing an array of steps', function() {
-      test('can render the array after the steps are defined', async function(assert) {
+      test('it exposes whether the step has a next step', async function(assert) {
         await render(hbs`
           {{#step-manager as |w|}}
-            <div data-test-active-step>
-              {{#w.step name='foo'}}
-                Foo
-              {{/w.step}}
-
-              {{#w.step name='bar'}}
-                Bar
-              {{/w.step}}
-            </div>
+            {{w.step name='foo'}}
+            {{w.step name='bar'}}
 
             {{#each w.steps as |step|}}
-              <a {{action w.transition-to step.name}} data-test-step-trigger={{step.name}}>
-                {{step.name}}
-              </a>
+              <p data-test-step={{step.name}}>
+                {{step.hasNext}}
+              </p>
             {{/each}}
           {{/step-manager}}
         `);
 
-        assert.dom('[data-test-step-trigger]').exists({ count: 2 });
-        assert.dom('[data-test-step-trigger="foo"]').hasText('foo');
-        assert.dom('[data-test-step-trigger="bar"]').hasText('bar');
-
-        assert.dom('[data-test-active-step]').hasText('Foo');
-
-        await click('[data-test-step-trigger="bar"]');
-
-        assert.dom('[data-test-active-step]').hasText('Bar');
+        assert
+          .dom('[data-test-step="foo"]')
+          .hasText('true', 'The first step has a next step');
+        assert
+          .dom('[data-test-step="bar"]')
+          .hasText('false', 'The second step does not have a next step');
       });
 
-      test('can render the array before the steps are defined', async function(assert) {
+      test('it exposes whether the step has a previous step', async function(assert) {
         await render(hbs`
           {{#step-manager as |w|}}
+            {{w.step name='foo'}}
+            {{w.step name='bar'}}
+
             {{#each w.steps as |step|}}
-              <a {{action w.transition-to step.name}} data-test-step-trigger={{step.name}}>
-                {{step.name}}
-              </a>
+              <p data-test-step={{step.name}}>
+                {{step.hasPrevious}}
+              </p>
             {{/each}}
-
-            <div data-test-active-step>
-              {{#w.step name='foo'}}
-                Foo
-              {{/w.step}}
-
-              {{#w.step name='bar'}}
-                Bar
-              {{/w.step}}
-            </div>
           {{/step-manager}}
         `);
 
-        assert.dom('[data-test-step-trigger]').exists({ count: 2 });
-        assert.dom('[data-test-step-trigger="foo"]').hasText('foo');
-        assert.dom('[data-test-step-trigger="bar"]').hasText('bar');
+        assert
+          .dom('[data-test-step="foo"]')
+          .hasText('false', 'The first step does not have a previous step');
+        assert
+          .dom('[data-test-step="bar"]')
+          .hasText('true', 'The second step has a previous step');
+      });
 
-        assert.dom('[data-test-active-step]').hasText('Foo');
+      test('it exposes whether the step is active', async function(assert) {
+        await render(hbs`
+          {{#step-manager as |w|}}
+            {{w.step name='foo'}}
+            {{w.step name='bar'}}
 
-        await click('[data-test-step-trigger="bar"]');
+            {{#each w.steps as |step|}}
+              <p data-test-step={{step.name}}>
+                {{step.isActive}}
+              </p>
+            {{/each}}
+          {{/step-manager}}
+        `);
 
-        assert.dom('[data-test-active-step]').hasText('Bar');
+        assert
+          .dom('[data-test-step="foo"]')
+          .hasText('true', 'The first step is active');
+        assert
+          .dom('[data-test-step="bar"]')
+          .hasText('false', 'The second step is not active');
+      });
+
+      module('rendering position', function() {
+        test('can render the array after the steps are defined', async function(assert) {
+          await render(hbs`
+            {{#step-manager as |w|}}
+              <div data-test-active-step>
+                {{#w.step name='foo'}}
+                  Foo
+                {{/w.step}}
+
+                {{#w.step name='bar'}}
+                  Bar
+                {{/w.step}}
+              </div>
+
+              {{#each w.steps as |step|}}
+                <a {{action w.transition-to step.name}} data-test-step-trigger={{step.name}}>
+                  {{step.name}}
+                </a>
+              {{/each}}
+            {{/step-manager}}
+          `);
+
+          assert.dom('[data-test-step-trigger]').exists({ count: 2 });
+          assert.dom('[data-test-step-trigger="foo"]').hasText('foo');
+          assert.dom('[data-test-step-trigger="bar"]').hasText('bar');
+
+          assert.dom('[data-test-active-step]').hasText('Foo');
+
+          await click('[data-test-step-trigger="bar"]');
+
+          assert.dom('[data-test-active-step]').hasText('Bar');
+        });
+
+        test('can render the array before the steps are defined', async function(assert) {
+          await render(hbs`
+            {{#step-manager as |w|}}
+              {{#each w.steps as |step|}}
+                <a {{action w.transition-to step.name}} data-test-step-trigger={{step.name}}>
+                  {{step.name}}
+                </a>
+              {{/each}}
+
+              <div data-test-active-step>
+                {{#w.step name='foo'}}
+                  Foo
+                {{/w.step}}
+
+                {{#w.step name='bar'}}
+                  Bar
+                {{/w.step}}
+              </div>
+            {{/step-manager}}
+          `);
+
+          assert.dom('[data-test-step-trigger]').exists({ count: 2 });
+          assert.dom('[data-test-step-trigger="foo"]').hasText('foo');
+          assert.dom('[data-test-step-trigger="bar"]').hasText('bar');
+
+          assert.dom('[data-test-active-step]').hasText('Foo');
+
+          await click('[data-test-step-trigger="bar"]');
+
+          assert.dom('[data-test-active-step]').hasText('Bar');
+        });
       });
     });
   });

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -250,9 +250,9 @@ module('step-manager', function(hooks) {
             {{w.step name='bar'}}
 
             {{#each w.steps as |step|}}
-              <p data-test-step={{step.name}}>
+              <button {{action w.transition-to step}} data-test-step={{step.name}}>
                 {{step.isActive}}
-              </p>
+              </button>
             {{/each}}
           {{/step-manager}}
         `);
@@ -263,6 +263,15 @@ module('step-manager', function(hooks) {
         assert
           .dom('[data-test-step="bar"]')
           .hasText('false', 'The second step is not active');
+
+        await click('button[data-test-step="bar"]');
+
+        assert
+          .dom('[data-test-step="foo"]')
+          .hasText('false', 'The first step has been deactivated');
+        assert
+          .dom('[data-test-step="bar"]')
+          .hasText('true', 'The second step has been activated');
       });
 
       test('can transition to a step by passing the node', async function(assert) {

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -213,8 +213,8 @@ module('step-manager', function(hooks) {
             </div>
 
             {{#each w.steps as |step|}}
-              <a {{action w.transition-to step}} data-test-step-trigger={{step}}>
-                {{step}}
+              <a {{action w.transition-to step.name}} data-test-step-trigger={{step.name}}>
+                {{step.name}}
               </a>
             {{/each}}
           {{/step-manager}}
@@ -235,8 +235,8 @@ module('step-manager', function(hooks) {
         await render(hbs`
           {{#step-manager as |w|}}
             {{#each w.steps as |step|}}
-              <a {{action w.transition-to step}} data-test-step-trigger={{step}}>
-                {{step}}
+              <a {{action w.transition-to step.name}} data-test-step-trigger={{step.name}}>
+                {{step.name}}
               </a>
             {{/each}}
 

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -265,6 +265,76 @@ module('step-manager', function(hooks) {
           .hasText('false', 'The second step is not active');
       });
 
+      module('context', function() {
+        test('it exposes step context', async function(assert) {
+          await render(hbs`
+            {{#step-manager as |w|}}
+              {{w.step name='foo' context='bar'}}
+
+              {{#each w.steps as |step|}}
+                <p data-test-step={{step.name}}>
+                  {{step.context}}
+                </p>
+              {{/each}}
+            {{/step-manager}}
+          `);
+
+          assert.dom('[data-test-step="foo"]').hasText('bar');
+        });
+
+        test('changes to the context are bound', async function(assert) {
+          this.set('context', { prop: 'foo' });
+
+          await render(hbs`
+            {{#step-manager as |w|}}
+              {{w.step name='foo' context=context}}
+
+              {{#each w.steps as |step|}}
+                <p data-test-step={{step.name}}>
+                  {{step.context.prop}}
+                </p>
+              {{/each}}
+            {{/step-manager}}
+          `);
+
+          assert
+            .dom('[data-test-step="foo"]')
+            .hasText('foo', 'Displays the original context value');
+
+          this.set('context.prop', 'bar');
+
+          assert
+            .dom('[data-test-step="foo"]')
+            .hasText('bar', 'Displays the updated context value');
+        });
+
+        test('can handle the context object being replaced', async function(assert) {
+          this.set('context', { prop: 'foo' });
+
+          await render(hbs`
+            {{#step-manager as |w|}}
+              {{w.step name='foo' context=context}}
+
+              {{#each w.steps as |step|}}
+                <p data-test-step={{step.name}}>
+                  {{step.context.prop}}
+                </p>
+              {{/each}}
+            {{/step-manager}}
+          `);
+
+          assert
+            .dom('[data-test-step="foo"]')
+            .hasText('foo', 'Displays the original context value');
+
+          this.set('context', { prop: 'bar' });
+
+          assert
+            .dom('[data-test-step="foo"]')
+            .hasText('bar', 'Displays the updated context value');
+        });
+      });
+
       module('rendering position', function() {
         test('can render the array after the steps are defined', async function(assert) {
           await render(hbs`

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -265,6 +265,33 @@ module('step-manager', function(hooks) {
           .hasText('false', 'The second step is not active');
       });
 
+      test('can transition to a step by passing the node', async function(assert) {
+        await render(hbs`
+          {{#step-manager as |w|}}
+            {{#w.step name='foo'}}
+              <p data-test-step="foo">Foo</p>
+            {{/w.step}}
+            {{#w.step name='bar'}}
+              <p data-test-step="bar">Bar</p>
+            {{/w.step}}
+
+            {{#each w.steps as |step|}}
+              <button {{action w.transition-to step}} data-test-transition-to={{step.name}}>
+                {{step.name}}
+              </button>
+            {{/each}}
+          {{/step-manager}}
+        `);
+
+        assert.dom('[data-test-step="foo"]').exists();
+        assert.dom('[data-test-step="bar"]').doesNotExist();
+
+        await click('button[data-test-transition-to="bar"]');
+
+        assert.dom('[data-test-step="foo"]').doesNotExist();
+        assert.dom('[data-test-step="bar"]').exists();
+      });
+
       module('context', function() {
         test('it exposes step context', async function(assert) {
           await render(hbs`

--- a/tests/unit/-private/state-machine/circular-test.js
+++ b/tests/unit/-private/state-machine/circular-test.js
@@ -111,15 +111,22 @@ module('-private/state-machine/circular', function() {
   });
 
   module('.stepTransitions', function() {
-    test('exposes an array of step names', function(assert) {
+    test('exposes an array of step objects', function(assert) {
       const m = new StateMachine();
       m.addStep('foo');
       m.addStep('bar');
-      assert.deepEqual(m.get('stepTransitions'), ['foo', 'bar']);
+      assert.deepEqual(m.get('stepTransitions').map(node => node.name), [
+        'foo',
+        'bar'
+      ]);
 
       m.addStep('baz');
 
-      assert.deepEqual(m.get('stepTransitions'), ['foo', 'bar', 'baz']);
+      assert.deepEqual(m.get('stepTransitions').map(node => node.name), [
+        'foo',
+        'bar',
+        'baz'
+      ]);
     });
   });
 });

--- a/tests/unit/-private/state-machine/linear-test.js
+++ b/tests/unit/-private/state-machine/linear-test.js
@@ -127,15 +127,22 @@ module('-private/state-machine/linear', function() {
   });
 
   module('.stepTransitions', function() {
-    test('exposes an array of step names', function(assert) {
+    test('exposes an array of step objects', function(assert) {
       const m = new StateMachine();
       m.addStep('foo');
       m.addStep('bar');
-      assert.deepEqual(m.get('stepTransitions'), ['foo', 'bar']);
+      assert.deepEqual(m.get('stepTransitions').map(node => node.name), [
+        'foo',
+        'bar'
+      ]);
 
       m.addStep('baz');
 
-      assert.deepEqual(m.get('stepTransitions'), ['foo', 'bar', 'baz']);
+      assert.deepEqual(m.get('stepTransitions').map(node => node.name), [
+        'foo',
+        'bar',
+        'baz'
+      ]);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,6 +132,13 @@
     babel-runtime "6.26.0"
     execa "0.9.0"
 
+"@ember-decorators/component@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/component/-/component-2.1.0.tgz#846ad4197a06c9814d02654e947c023d35107cee"
+  dependencies:
+    "@ember-decorators/utils" "^2.1.0"
+    ember-cli-babel "^6.6.0"
+
 "@ember-decorators/object@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@ember-decorators/object/-/object-2.1.0.tgz#725c790c030299a4bc8c15f21048c3c0abc1499c"


### PR DESCRIPTION
- Replaces the exposed array of `StepName` with an array of `StepNode`, which contains the `StepName` as well as additional metadata (`hasNext`, `hasPrevious`, `isActive` and `context`).
- Introduces the concept of step "context", as proposed in #104, which is some object that can be passed into the `w.step` and threaded through to the `step` object exposed in the `w.steps` array.

## Todo

- [x] Prepare notes on migrating to the new `steps` array
- [x] Ensure that documentation references the new API