### PR TITLE
fix: avoid resetting the step manager on any attribute changes

### DIFF
--- a/addon/components/step-manager.ts
+++ b/addon/components/step-manager.ts
@@ -71,6 +71,12 @@ export default class StepManagerComponent extends Component {
   linear!: boolean;
 
   /**
+   * @property {boolean} boolean
+   * @private
+   */
+  _watchCurrentStep!: boolean;
+
+  /**
    * @property {BaseStateMachine} transitions state machine for transitions
    * @private
    */
@@ -85,6 +91,7 @@ export default class StepManagerComponent extends Component {
       'currentStep'
     );
 
+    this._watchCurrentStep = isPresent(currentStep);
     const startingStep = isNone(initialStep) ? currentStep : initialStep;
 
     if (!isPresent(this.linear)) {
@@ -113,13 +120,15 @@ export default class StepManagerComponent extends Component {
   }
 
   didUpdateAttrs() {
-    const newStep = this.currentStep;
+    if (this._watchCurrentStep) {
+      const newStep = this.currentStep;
 
-    if (typeof newStep === 'undefined') {
-      const firstStep = get(this.transitions, 'firstStep');
-      this.transitionTo(firstStep);
-    } else {
-      this.transitionTo(newStep);
+      if (typeof newStep === 'undefined') {
+        const firstStep = get(this.transitions, 'firstStep');
+        this.transitionTo(firstStep);
+      } else {
+        this.transitionTo(newStep);
+      }
     }
   }
 

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -109,6 +109,31 @@ module('step-manager', function(hooks) {
 
         assert.equal(this.get('step'), 'first');
       });
+
+      test('does not reset back to first step on any attribute change', async function(assert) {
+        this.set('initialStep', 'second');
+        this.set('randomAttribute', 'initial value');
+
+        await render(hbs`
+          {{#step-manager randomAttribute=randomAttribute initialStep=initialStep as |w|}}
+            {{#w.step name='first'}}
+              <div data-test-first></div>
+            {{/w.step}}
+            {{#w.step name='second'}}
+              <div data-test-second></div>
+            {{/w.step}}
+          {{/step-manager}}
+        `);
+
+        assert.dom('[data-test-second]').exists();
+        assert.dom('[data-test-first]').doesNotExist();
+
+        this.set('initialStep', 'second');
+        this.set('randomAttribute', 'a new value');
+
+        assert.dom('[data-test-second]').exists();
+        assert.dom('[data-test-first]').doesNotExist();
+      });
     });
   });
 


### PR DESCRIPTION
Fixes an edge case where if the binding for `initialStep` is invalidated it resets the step manager back to the first step.

The solution was only observe changes to currentPath if it was provided when the component was instantiated.