### PR TITLE
chore: remove activation hooks

### DIFF
--- a/addon/-private/state-machine/-base.js
+++ b/addon/-private/state-machine/-base.js
@@ -31,8 +31,8 @@ export default class BaseStateMachine extends EmberObject {
     return this.stepTransitions.find(stepNode => stepNode.name === currentStep);
   }
 
-  addStep(name, context, onActivate, onDeactivate) {
-    const node = new StepNode(this, name, context, onActivate, onDeactivate);
+  addStep(name, context) {
+    const node = new StepNode(this, name, context);
     this.stepTransitions.pushObject(node);
 
     if (typeof this.currentStep === 'undefined') {

--- a/addon/-private/step-node.js
+++ b/addon/-private/step-node.js
@@ -3,12 +3,10 @@ import { isPresent } from '@ember/utils';
 import { computed } from '@ember/object';
 
 export default class StepNode {
-  constructor(sm, name, context, onActivate, onDeactivate) {
+  constructor(sm, name, context) {
     this.sm = sm;
     this.name = name;
     this.context = context;
-    this.onActivate = onActivate;
-    this.onDeactivate = onDeactivate;
   }
 
   get hasNext() {

--- a/addon/components/step-manager.js
+++ b/addon/components/step-manager.js
@@ -144,14 +144,12 @@ export default class StepManagerComponent extends Component {
   registerStepComponent(stepComponent) {
     const name = get(stepComponent, 'name');
     const context = get(stepComponent, 'context');
-    const onActivate = get(stepComponent, 'onActivate');
-    const onDeactivate = get(stepComponent, 'onDeactivate');
     const transitions = this.transitions;
 
     stepComponent.transitions = transitions;
 
     schedule('actions', () => {
-      transitions.addStep(name, context, onActivate, onDeactivate);
+      transitions.addStep(name, context);
     });
   }
 
@@ -174,24 +172,12 @@ export default class StepManagerComponent extends Component {
   @action
   transitionTo(to) {
     const destination = to instanceof StepNode ? to.name : to;
-    const transitions = get(this, 'transitions');
     const onTransition = get(this, 'onTransition');
-    let currentStepNode = get(transitions, 'currentStepNode');
-
-    if (currentStepNode && currentStepNode.onDeactivate) {
-      currentStepNode.onDeactivate();
-    }
 
     this.transitions.activate(destination);
 
     if (onTransition) {
       onTransition(destination);
-    }
-
-    currentStepNode = get(transitions, 'currentStepNode');
-
-    if (currentStepNode && currentStepNode.onActivate) {
-      currentStepNode.onActivate();
     }
   }
 

--- a/addon/components/step-manager/step.js
+++ b/addon/components/step-manager/step.js
@@ -18,8 +18,6 @@ export default class StepComponent extends Component {
 
   name;
   context;
-  onActivate;
-  onDeactivate;
 
   currentStep;
 
@@ -46,8 +44,6 @@ export default class StepComponent extends Component {
 
     this.addObserver('name', this, failOnNameChange);
     this.addObserver('context', this, this.updateContext);
-    this.addObserver('onActivate', this, this.updateOnActivate);
-    this.addObserver('onDeactivate', this, this.updateOnDeactivate);
 
     this['register-step'](this);
   }
@@ -55,8 +51,6 @@ export default class StepComponent extends Component {
   willDestroyElement() {
     this.removeObserver('name', this, failOnNameChange);
     this.removeObserver('context', this, this.updateContext);
-    this.removeObserver('onActivate', this, this.updateOnActivate);
-    this.removeObserver('onDeactivate', this, this.updateOnDeactivate);
     this['remove-step'](this);
   }
 
@@ -64,18 +58,6 @@ export default class StepComponent extends Component {
     const context = get(this, 'context');
 
     this['update-step-node'](this, 'context', context);
-  }
-
-  updateOnActivate() {
-    const onActivate = get(this, 'onActivate');
-
-    this['update-step-node'](this, 'onActivate', onActivate);
-  }
-
-  updateOnDeactivate() {
-    const onDeactivate = get(this, 'onDeactivate');
-
-    this['update-step-node'](this, 'onDeactivate', onDeactivate);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@commitlint/config-conventional": "^6.1.3",
     "@commitlint/travis-cli": "^6.2.0",
     "@ember/optional-features": "^0.6.3",
+    "@ember/render-modifiers": "^1.0.0",
     "@ember/test-helpers": "^0.7.18",
     "babel-eslint": "^10.0.1",
     "broccoli-asset-rev": "^2.7.0",
@@ -80,7 +81,9 @@
     "ember-cli-htmlbars": "^3.0.0",
     "ember-decorators-polyfill": "^1.0.4"
   },
-  "keywords": ["ember-addon"],
+  "keywords": [
+    "ember-addon"
+  ],
   "repository": "https://github.com/alexlafroscia/ember-steps",
   "license": "MIT",
   "author": "Alex LaFroscia <alex@lafroscia.com>",

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -877,121 +877,17 @@ module('step-manager', function(hooks) {
   });
 
   module('activation hooks', function() {
-    test('onDeactivate action gets called', async function(assert) {
+    test('using `will-destroy` when a step is deactivated', async function(assert) {
       const onDeactivate = td.function();
       this.set('onDeactivate', onDeactivate);
 
       await render(hbs`
         {{#step-manager as |w|}}
-          {{w.step name='first' onDeactivate=(action onDeactivate)}}
-          {{w.step name='second'}}
-
-          <button {{action w.transition-to 'second'}}>
-            Next
-          </button>
-        {{/step-manager}}
-      `);
-
-      await click('button');
-
-      assert.verify(onDeactivate());
-    });
-
-    test('onActivate action gets called', async function(assert) {
-      const onActivate = td.function();
-      this.set('onActivate', onActivate);
-
-      await render(hbs`
-        {{#step-manager as |w|}}
-          {{w.step name='first'}}
-          {{w.step name='second' onActivate=(action onActivate)}}
-
-          <button {{action w.transition-to 'second'}}>
-            Next
-          </button>
-        {{/step-manager}}
-      `);
-
-      await click('button');
-
-      assert.verify(onActivate());
-    });
-
-    test('onActivate action gets called when the current step property changes', async function(assert) {
-      const onActivate = td.function();
-      this.set('onActivate', onActivate);
-      this.set('tab', 'first');
-
-      await render(hbs`
-        {{#step-manager currentStep=tab as |w|}}
           {{#w.step name='first'}}
-            This content is on the first tab
+            <div {{will-destroy onDeactivate}}>
+              Step Content
+            </div>
           {{/w.step}}
-
-          {{#w.step name='second' onActivate=(action onActivate)}}
-            This content is on the second tab
-          {{/w.step}}
-        {{/step-manager}}
-      `);
-
-      this.set('tab', 'second');
-      assert.verify(onActivate());
-    });
-
-    test('onDeactivate action gets called when the current step property changes', async function(assert) {
-      const onDeactivate = td.function();
-      this.set('onDeactivate', onDeactivate);
-      this.set('tab', 'first');
-
-      await render(hbs`
-        {{#step-manager currentStep=tab as |w|}}
-          {{#w.step name='first' onDeactivate=(action onDeactivate)}}
-            This content is on the first tab
-          {{/w.step}}
-
-          {{#w.step name='second'}}
-            This content is on the second tab
-          {{/w.step}}
-        {{/step-manager}}
-      `);
-
-      this.set('tab', 'second');
-      assert.verify(onDeactivate());
-    });
-
-    test('onActivate action can be updated', async function(assert) {
-      const onActivate = td.function();
-      this.set('onActivate', onActivate);
-
-      const updatedOnActivate = td.function();
-
-      await render(hbs`
-        {{#step-manager as |w|}}
-          {{w.step name='first'}}
-          {{w.step name='second' onActivate=(action onActivate)}}
-
-          <button {{action w.transition-to 'second'}}>
-            Next
-          </button>
-        {{/step-manager}}
-      `);
-
-      this.set('onActivate', updatedOnActivate);
-      await click('button');
-
-      assert.verify(updatedOnActivate());
-      assert.verify(onActivate(), { times: 0, ignoreExtraArgs: true });
-    });
-
-    test('onDeactivate action can be updated', async function(assert) {
-      const onDeactivate = td.function();
-      this.set('onDeactivate', onDeactivate);
-
-      const updatedOnDeactivate = td.function();
-
-      await render(hbs`
-        {{#step-manager as |w|}}
-          {{w.step name='first' onDeactivate=(action onDeactivate)}}
           {{w.step name='second'}}
 
           <button {{action w.transition-to 'second'}}>
@@ -1000,11 +896,33 @@ module('step-manager', function(hooks) {
         {{/step-manager}}
       `);
 
-      this.set('onDeactivate', updatedOnDeactivate);
       await click('button');
 
-      assert.verify(updatedOnDeactivate());
-      assert.verify(onDeactivate(), { times: 0, ignoreExtraArgs: true });
+      assert.verify(onDeactivate(), { ignoreExtraArgs: true });
+    });
+
+    test('using `did-insert` when a step is activated', async function(assert) {
+      const onActivate = td.function();
+      this.set('onActivate', onActivate);
+
+      await render(hbs`
+        {{#step-manager as |w|}}
+          {{w.step name='first'}}
+          {{#w.step name='second'}}
+            <div {{did-insert onActivate}}>
+              Step Content
+            </div>
+          {{/w.step}}
+
+          <button {{action w.transition-to 'second'}}>
+            Next
+          </button>
+        {{/step-manager}}
+      `);
+
+      await click('button');
+
+      assert.verify(onActivate(), { ignoreExtraArgs: true });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -959,6 +959,14 @@
     ember-cli-babel "^6.16.0"
     ember-compatibility-helpers "^1.1.1"
 
+"@ember/render-modifiers@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.0.tgz#dc1e4c615e38507da4b6a80f6e4b27fe4d37ec8f"
+  integrity sha512-TqUW7exzLUwnzqHqKbo5ui0rvrS/YkbRlFD+h07kDYVFJkS2uPwkQE/K4YDeTywqN6er7VamFwl7Og98sPjmiQ==
+  dependencies:
+    ember-cli-babel "^7.1.2"
+    ember-modifier-manager-polyfill "^1.0.1"
+
 "@ember/test-helpers@^0.7.18":
   version "0.7.21"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-0.7.21.tgz#1bb6555e7d201d86800671a0ba64e70d3d23a3a0"
@@ -5684,7 +5692,7 @@ ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.2, ember-cli-babel@^7.1.4:
     ensure-posix-path "^1.0.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.3, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.1.3, ember-cli-babel@^7.4.2, ember-cli-babel@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.7.3.tgz#f94709f6727583d18685ca6773a995877b87b8a0"
   integrity sha512-/LWwyKIoSlZQ7k52P+6agC7AhcOBqPJ5C2u27qXHVVxKvCtg6ahNuRk/KmfZmV4zkuw4EjTZxfJE1PzpFyHkXg==
@@ -6530,6 +6538,15 @@ ember-modal-dialog@3.0.0-beta.3:
     ember-cli-version-checker "^2.1.0"
     ember-ignore-children-helper "^1.0.1"
     ember-wormhole "^0.5.5"
+
+ember-modifier-manager-polyfill@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.0.3.tgz#6554b70d09a7d3b80d366b72ed482fb9a3e813c0"
+  integrity sha512-d8Uz0BhAZaqzttF4NXTwJ/A8uPrgd7fMho5jh89BfzJAHu5WZfGewX9cbjh3m6f512ZyxkIeeolw3Z5/Jyaujg==
+  dependencies:
+    ember-cli-babel "^7.4.2"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.2.0"
 
 ember-qunit-assert-helpers@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
At the time this feature was created, it made sense to support hooks that were called when a step was activated or deactivated. However, with the advent of more flexible element modifiers, this is no longer necessary as it is easy to re-create the same behavior using features that Ember provides official support for.

Closes #120 - Adding documentation for hooks is no longer necessary
Closes #129 - `did-insert` will not have the problem experiences on first render like `onActivate` did

BREAKING CHANGE: `onActivate` and `onDeactivate` should instead be called by `did-insert` or `will-destroy` on element inside the step definition.