### PR TITLE
Remove obsolete `@ember-decorators/component` dependency

### DIFF
--- a/addon/components/step-manager.js
+++ b/addon/components/step-manager.js
@@ -6,7 +6,6 @@ import { isPresent, isNone } from '@ember/utils';
 import { schedule } from '@ember/runloop';
 import { assert } from '@ember/debug';
 import { action, computed } from '@ember/object';
-import { tagName } from '@ember-decorators/component';
 
 import CircularStateMachine from '../-private/state-machine/circular';
 import LinearStateMachine from '../-private/state-machine/linear';
@@ -43,9 +42,10 @@ import StepNode from '../-private/step-node';
  * @public
  * @hide
  */
-@tagName('')
 export default class StepManagerComponent extends Component {
   layout = layout;
+
+  tagName = '';
 
   /* Optionally can be provided to override the initial step to render */
   initialStep;

--- a/addon/components/step-manager/step.js
+++ b/addon/components/step-manager/step.js
@@ -3,7 +3,6 @@ import { get, set } from '@ember/object';
 import { isPresent } from '@ember/utils';
 import { assert } from '@ember/debug';
 import { computed } from '@ember/object';
-import { tagName } from '@ember-decorators/component';
 
 // @ts-ignore: Ignore import of compiled template
 import layout from '../../templates/components/step-manager/step';
@@ -12,9 +11,10 @@ function failOnNameChange() {
   assert('The `name` property should never change');
 }
 
-@tagName('')
 export default class StepComponent extends Component {
   layout = layout;
+
+  tagName = '';
 
   name;
   context;

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "travis-deploy-once": "^5.0.0"
   },
   "dependencies": {
-    "@ember-decorators/component": "^5.2.0",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^3.0.0",
     "ember-decorators-polyfill": "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,25 +937,6 @@
     babel-runtime "6.26.0"
     execa "0.9.0"
 
-"@ember-decorators/component@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/component/-/component-5.2.0.tgz#266955b517cf33a1cae4fa48c0794337b628a194"
-  integrity sha512-ZKsh116MQ0nWPxiQ2hls6Ok5QbZtSEJpt9LA330w2yMYy1c67YOD2XUG9fDyZ72M0P1Jzt/hd/8HJSqdJfjD5A==
-  dependencies:
-    "@ember-decorators/utils" "^5.2.0"
-    ember-cli-babel "^7.1.3"
-
-"@ember-decorators/utils@^5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-5.2.0.tgz#75c79b6d2b69b7d9224a3697176bc198d4e274a9"
-  integrity sha512-GjVPkvqprQNOtsut16Nk3M/UWmqCDDFVSfvUyqasaPlYt9+d6w0y6XrjSnQ6+3VOyk4rUWE+3u0tJoukgeWVLw==
-  dependencies:
-    babel-plugin-debug-macros "^0.2.0"
-    ember-cli-babel "^7.1.3"
-    ember-cli-version-checker "^3.0.0"
-    ember-compatibility-helpers "^1.1.2"
-    semver "^6.0.0"
-
 "@ember/optional-features@^0.6.3":
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/@ember/optional-features/-/optional-features-0.6.4.tgz#8199f853c1781234fcb1f05090cddd0b822bff69"


### PR DESCRIPTION
We can assign `tagName` directly instead of using the non-standard `tagName` decorator.

The advantage is that this gets rid of the `ember-decorators` v5 dependency which is causing issues like https://github.com/ember-decorators/ember-decorators/issues/417

/cc @alexlafroscia 