### PR TITLE
refactor: yield step component as `Step`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,35 +24,35 @@ Cool, right? Ehh, it doesn't do much yet -- we need to add some steps.
 
 ```handlebars
 <StepManager as |w|>
-  <w.step @name="a">
+  <w.Step @name="a">
     This is the first step!
-  </w.step>
+  </w.Step>
 
-  <w.step @name="b">
+  <w.Step @name="b">
     This is the second step!
-  </w.step>
+  </w.Step>
 </StepManager>
 ```
 
-As you may have guessed, the first `w.step` component, `a`, will be visible initially, and `b` will be invisible. Note that these names are important. Why? Because we need a way to transition between them!
+As you may have guessed, the first `w.Step` component, `a`, will be visible initially, and `b` will be invisible. Note that these names are important. Why? Because we need a way to transition between them!
 
 ```handlebars
 <StepManager as |w|>
-  <w.step @name="a">
+  <w.Step @name="a">
     This is the first step!
 
     <button {{on "click" (fn w.transition-to "b")}}>
       Next, please!
     </button>
-  </w.step>
+  </w.Step>
 
-  <w.step @name="b">
+  <w.Step @name="b">
     This is the second step!
 
     <button {{on "click" (fn w.transition-to "a")}}>
       Wait, go back!
     </button>
-  </w.step>
+  </w.Step>
 </StepManager>
 ```
 

--- a/addon/components/step-manager.hbs
+++ b/addon/components/step-manager.hbs
@@ -1,6 +1,6 @@
 {{yield
   (hash
-    step=(component "step-manager/step"
+    Step=(component "step-manager/step"
       register-step=this.registerStepComponent
       remove-step=this.removeStepComponent
       update-step-node=this.updateStepNode

--- a/addon/components/step-manager.js
+++ b/addon/components/step-manager.js
@@ -13,18 +13,18 @@ import StepNode from '../-private/step-node';
 /**
  * ```hbs
  * <StepManager as |w|>
- *   <w.step @name="first">
+ *   <w.Step @name="first">
  *     <h1>First Step</h1>
- *   </w.step>
- *   <w.step @name="second">
+ *   </w.Step>
+ *   <w.Step @name="second">
  *     <h1>Second Step</h1>
- *   </w.step>
+ *   </w.Step>
  * </StepManager>
  * ```
  *
  * @class StepManagerComponent
  * @yield {Hash} w Wizard Properties
- * @yield {StepComponent} w.step The component to create steps
+ * @yield {StepComponent} w.Step The component to create steps
  * @yield {boolean} w.hasNextStep Whether or not the current step has a "next" step
  * @yield {boolean} w.hasPreviousStep Whether or not the current step has a "previous" step
  * @yield {string} w.currentStep Reflects the name of the active step

--- a/addon/components/step-manager/step.js
+++ b/addon/components/step-manager/step.js
@@ -6,9 +6,9 @@ import { guidFor } from '@ember/object/internals';
 
 /**
  * ```hbs
- * <w.step @name="first">
+ * <w.Step @name="first">
  *   <h1>First Step</h1>
- * </w.step>
+ * </w.Step>
  * ```
  *
  * @class StepComponent

--- a/tests/dummy/app/docs/cookbook/dynamic-definition/basic-demo/template.hbs
+++ b/tests/dummy/app/docs/cookbook/dynamic-definition/basic-demo/template.hbs
@@ -2,9 +2,9 @@
   <demo.example @name="dynamic-definition-basic-example.hbs">
     <StepManager as |w|>
       {{#each this.data as |content|}}
-        <w.step>
+        <w.Step>
           {{content}}
-        </w.step>
+        </w.Step>
       {{/each}}
 
       <ControlGroup>

--- a/tests/dummy/app/docs/cookbook/tabs/demo-basic-tabs/template.hbs
+++ b/tests/dummy/app/docs/cookbook/tabs/demo-basic-tabs/template.hbs
@@ -16,13 +16,13 @@
         </TabButton>
       </TabGroup>
 
-      <w.step @name="first">
+      <w.Step @name="first">
         This content is on the first tab
-      </w.step>
+      </w.Step>
 
-      <w.step @name="second">
+      <w.Step @name="second">
         This content is on the second tab
-      </w.step>
+      </w.Step>
     </StepManager>
   </demo.example>
 

--- a/tests/dummy/app/docs/cookbook/tabs/query-param/template.md
+++ b/tests/dummy/app/docs/cookbook/tabs/query-param/template.md
@@ -20,13 +20,13 @@ Often times, you might want to store the active tab in the URL, so that the user
     </TabGroup>
 
     <StepManager @currentStep={{this.tab}} as |w|>
-      <w.step @name="first">
+      <w.Step @name="first">
         This content is on the first tab
-      </w.step>
+      </w.Step>
 
-      <w.step @name="second">
+      <w.Step @name="second">
         This content is on the second tab
-      </w.step>
+      </w.Step>
     </StepManager>
   </demo.example>
 

--- a/tests/dummy/app/docs/cookbook/wizard/demo-basic-wizard/template.hbs
+++ b/tests/dummy/app/docs/cookbook/wizard/demo-basic-wizard/template.hbs
@@ -1,17 +1,17 @@
 <DocsDemo as |demo|>
   <demo.example @name="demo-basic-wizard.hbs">
     <StepManager as |w|>
-      <w.step>
+      <w.Step>
         This content is on the first step. You can only go forward.
-      </w.step>
+      </w.Step>
 
-      <w.step>
+      <w.Step>
         This content is on the second step. You can go forward or backward.
-      </w.step>
+      </w.Step>
 
-      <w.step>
+      <w.Step>
         This content is on the third step. You can only go backward.
-      </w.step>
+      </w.Step>
 
       <ControlGroup>
         <button

--- a/tests/dummy/app/docs/cookbook/wizard/demo-wizard-with-progress-indicator/template.hbs
+++ b/tests/dummy/app/docs/cookbook/wizard/demo-wizard-with-progress-indicator/template.hbs
@@ -1,17 +1,17 @@
 <DocsDemo as |demo|>
   <demo.example @name="demo-wizard-with-progress-indicator.hbs">
     <StepManager as |w|>
-      <w.step>
+      <w.Step>
         This content is on the first step
-      </w.step>
+      </w.Step>
 
-      <w.step>
+      <w.Step>
         This content is on the second step
-      </w.step>
+      </w.Step>
 
-      <w.step>
+      <w.Step>
         This content is on the third step
-      </w.step>
+      </w.Step>
 
       <ControlGroup>
         <button

--- a/tests/dummy/app/docs/features/inactive/example-1/template.hbs
+++ b/tests/dummy/app/docs/features/inactive/example-1/template.hbs
@@ -1,7 +1,7 @@
 <DocsDemo as |demo|>
   <demo.example @name="inactive-steps-example-1.hbs">
     <StepManager as |w|>
-      {{#w.step name="first"}}
+      {{#w.Step name="first"}}
         <h1>The first step is active</h1>
       {{else}}
         <button
@@ -10,9 +10,9 @@
         >
           The first step is inactive. Activate it.
         </button>
-      {{/w.step}}
+      {{/w.Step}}
 
-      {{#w.step name="second"}}
+      {{#w.Step name="second"}}
         <h1>The second step is active</h1>
       {{else}}
         <button
@@ -21,7 +21,7 @@
         >
           The second step is inactive. Activate it.
         </button>
-      {{/w.step}}
+      {{/w.Step}}
     </StepManager>
   </demo.example>
 

--- a/tests/dummy/app/docs/features/state-manager/cyclical/template.hbs
+++ b/tests/dummy/app/docs/features/state-manager/cyclical/template.hbs
@@ -1,13 +1,13 @@
 <DocsDemo as |demo|>
   <demo.example @name="demo-cyclical-steps-cyclical.hbs">
     <StepManager @linear={{false}} as |w|>
-      <w.step>
+      <w.Step>
         First step has both a "next" and "previous" step
-      </w.step>
+      </w.Step>
 
-      <w.step>
+      <w.Step>
         Second step has both a "next" and "previous" step
-      </w.step>
+      </w.Step>
 
       <ControlGroup>
         <button

--- a/tests/dummy/app/docs/features/state-manager/linear/template.hbs
+++ b/tests/dummy/app/docs/features/state-manager/linear/template.hbs
@@ -1,13 +1,13 @@
 <DocsDemo as |demo|>
   <demo.example @name="demo-cyclical-steps-linear.hbs">
     <StepManager as |w|>
-      <w.step>
+      <w.Step>
         First step has only a "next" step
-      </w.step>
+      </w.Step>
 
-      <w.step>
+      <w.Step>
         Second step has only a "previous" step
-      </w.step>
+      </w.Step>
 
       <ControlGroup>
         <button

--- a/tests/dummy/app/docs/features/state-manager/step-yielded/template.hbs
+++ b/tests/dummy/app/docs/features/state-manager/step-yielded/template.hbs
@@ -1,17 +1,17 @@
 <DocsDemo as |demo|>
   <demo.example @name="demo-cyclical-steps-step-yielded.hbs">
     <StepManager as |w|>
-      <w.step as |step|>
+      <w.Step as |step|>
         <h3>First</h3>
         There is a first step: {{step.hasNext}} <br>
         There is a previous step: {{step.hasPrevious}}
-      </w.step>
+      </w.Step>
 
-      <w.step as |step|>
+      <w.Step as |step|>
         <h3>Second</h3>
         There is a first step: {{step.hasNext}} <br>
         There is a previous step: {{step.hasPrevious}}
-      </w.step>
+      </w.Step>
 
       <ControlGroup>
         <button

--- a/tests/dummy/app/docs/features/validating-steps/basic-usage/template.hbs
+++ b/tests/dummy/app/docs/features/validating-steps/basic-usage/template.hbs
@@ -1,7 +1,7 @@
 <DocsDemo as |demo|>
   <demo.example @name="validating-steps-basic-usage.hbs">
     <StepManager as |w|>
-      <w.step>
+      <w.Step>
         <input placeholder="Enter password" value={{this.password}}>
 
         <ControlGroup>
@@ -12,11 +12,11 @@
             Check Password
           </button>
         </ControlGroup>
-      </w.step>
+      </w.Step>
 
-      <w.step>
+      <w.Step>
         Great job! You got the password right
-      </w.step>
+      </w.Step>
     </StepManager>
   </demo.example>
 

--- a/tests/dummy/app/docs/features/validating-steps/with-did-transition/template.hbs
+++ b/tests/dummy/app/docs/features/validating-steps/with-did-transition/template.hbs
@@ -1,7 +1,7 @@
 <DocsDemo as |demo|>
   <demo.example @name="validating-steps-did-transition.hbs">
     <StepManager as |w|>
-      <w.step>
+      <w.Step>
         <input placeholder="Enter password" value={{this.password}}>
 
         <ControlGroup>
@@ -12,9 +12,9 @@
             Check Password
           </button>
         </ControlGroup>
-      </w.step>
+      </w.Step>
 
-      <w.step>
+      <w.Step>
         Great job! You got the password right
 
         <ControlGroup>
@@ -25,7 +25,7 @@
             Reset
           </button>
         </ControlGroup>
-      </w.step>
+      </w.Step>
     </StepManager>
   </demo.example>
 

--- a/tests/dummy/app/docs/features/validating-steps/with-ember-concurrency/template.hbs
+++ b/tests/dummy/app/docs/features/validating-steps/with-ember-concurrency/template.hbs
@@ -1,7 +1,7 @@
 <DocsDemo as |demo|>
   <demo.example @name="validating-steps-ember-concurrency.hbs">
     <StepManager as |w|>
-      <w.step>
+      <w.Step>
         <input placeholder="Enter password" value={{this.password}}>
 
         <ControlGroup>
@@ -13,11 +13,11 @@
             Check Password
           </button>
         </ControlGroup>
-      </w.step>
+      </w.Step>
 
-      <w.step>
+      <w.Step>
         Great job! You got the password right
-      </w.step>
+      </w.Step>
     </StepManager>
   </demo.example>
 

--- a/tests/dummy/app/docs/index/template.md
+++ b/tests/dummy/app/docs/index/template.md
@@ -24,35 +24,35 @@ Cool, right?  Ehh, it doesn't do much yet -- we need to add some steps.
 
 ```handlebars
 <StepManager as |w|>
-  <w.step @name="a">
+  <w.Step @name="a">
     This is the first step!
-  </w.step>
+  </w.Step>
 
-  <w.step @name="b">
+  <w.Step @name="b">
     This is the second step!
-  </w.step>
+  </w.Step>
 </StepManager>
 ```
 
-As you may have guessed, the first `w.step` component, `a`, will be visible initially, and `b` will be invisible.  Note that these names are important.  Why?  Because we need a way to transition between them!
+As you may have guessed, the first `w.Step` component, `a`, will be visible initially, and `b` will be invisible.  Note that these names are important.  Why?  Because we need a way to transition between them!
 
 ```handlebars
 <StepManager as |w|>
-  <w.step @name="a">
+  <w.Step @name="a">
     This is the first step!
 
     <button {{on "click" (fn w.transition-to "b")}}>
       Next, please!
     </button>
-  </w.step>
+  </w.Step>
 
-  <w.step @name="b">
+  <w.Step @name="b">
     This is the second step!
 
     <button {{on "click" (fn w.transition-to "a")}}>
       Wait, go back!
     </button>
-  </w.step>
+  </w.Step>
 </StepManager>
 ```
 

--- a/tests/integration/step-manager-test.js
+++ b/tests/integration/step-manager-test.js
@@ -12,13 +12,13 @@ module('step-manager', function (hooks) {
     test('setting the initial visible step', async function (assert) {
       await render(hbs`
         <StepManager @currentStep="second" as |w|>
-          <w.step @name="first">
+          <w.Step @name="first">
             <div data-test-first></div>
-          </w.step>
+          </w.Step>
 
-          <w.step @name="second">
+          <w.Step @name="second">
             <div data-test-second></div>
-          </w.step>
+          </w.Step>
         </StepManager>
       `);
 
@@ -31,13 +31,13 @@ module('step-manager', function (hooks) {
 
       await render(hbs`
         <StepManager @currentStep={{step}} as |w|>
-          <w.step @name="first">
+          <w.Step @name="first">
             <div data-test-first></div>
-          </w.step>
+          </w.Step>
 
-          <w.step @name="second">
+          <w.Step @name="second">
             <div data-test-second></div>
-          </w.step>
+          </w.Step>
         </StepManager>
       `);
 
@@ -77,8 +77,8 @@ module('step-manager', function (hooks) {
 
       await render(hbs`
         {{#step-manager currentStep=step as |w|}}
-          {{w.step name='first'}}
-          {{w.step name='second'}}
+          {{w.Step name='first'}}
+          {{w.Step name='second'}}
 
           <button {{action w.transition-to 'second'}}>
             Next
@@ -97,8 +97,8 @@ module('step-manager', function (hooks) {
 
       await render(hbs`
         {{#step-manager currentStep=step onTransition=onTransition as |w|}}
-          {{w.step name='first'}}
-          {{w.step name='second'}}
+          {{w.Step name='first'}}
+          {{w.Step name='second'}}
 
           <button {{action w.transition-to 'second'}}>
             Next
@@ -119,8 +119,8 @@ module('step-manager', function (hooks) {
 
       await render(hbs`
         {{#step-manager currentStep=step onTransition=(action (mut step)) as |w|}}
-          {{w.step name='first'}}
-          {{w.step name='second'}}
+          {{w.Step name='first'}}
+          {{w.Step name='second'}}
 
           <button {{action w.transition-to 'second'}}>
             Next
@@ -143,12 +143,12 @@ module('step-manager', function (hooks) {
 
       await render(hbs`
         {{#step-manager randomAttribute=randomAttribute initialStep=initialStep as |w|}}
-          {{#w.step name='first'}}
+          {{#w.Step name='first'}}
             <div data-test-first></div>
-          {{/w.step}}
-          {{#w.step name='second'}}
+          {{/w.Step}}
+          {{#w.Step name='second'}}
             <div data-test-second></div>
-          {{/w.step}}
+          {{/w.Step}}
         {{/step-manager}}
       `);
 
@@ -167,13 +167,13 @@ module('step-manager', function (hooks) {
     test('it can set the initial visible step', async function (assert) {
       await render(hbs`
         {{#step-manager initialStep='second' as |w|}}
-          {{#w.step name='first'}}
+          {{#w.Step name='first'}}
             <div data-test-first></div>
-          {{/w.step}}
+          {{/w.Step}}
 
-          {{#w.step name='second'}}
+          {{#w.Step name='second'}}
             <div data-test-second></div>
-          {{/w.step}}
+          {{/w.Step}}
         {{/step-manager}}
       `);
 
@@ -185,13 +185,13 @@ module('step-manager', function (hooks) {
       this.set('initialStep', 'second');
       await render(hbs`
         {{#step-manager initialStep=initialStep as |w|}}
-          {{#w.step name='first'}}
+          {{#w.Step name='first'}}
             <div data-test-first></div>
-          {{/w.step}}
+          {{/w.Step}}
 
-          {{#w.step name='second'}}
+          {{#w.Step name='second'}}
             <div data-test-second></div>
-          {{/w.step}}
+          {{/w.Step}}
 
           <button {{action w.transition-to 'first'}}>
             To First
@@ -209,13 +209,13 @@ module('step-manager', function (hooks) {
   test('renders the first step in the DOM if no `currentStep` is present', async function (assert) {
     await render(hbs`
       {{#step-manager as |w|}}
-        {{#w.step name='first'}}
+        {{#w.Step name='first'}}
           <div data-test-first></div>
-        {{/w.step}}
+        {{/w.Step}}
 
-        {{#w.step name='second'}}
+        {{#w.Step name='second'}}
           <div data-test-second></div>
-        {{/w.step}}
+        {{/w.Step}}
       {{/step-manager}}
     `);
 
@@ -227,7 +227,7 @@ module('step-manager', function (hooks) {
     await render(hbs`
       <div id="steps">
         {{#step-manager as |w|}}
-          {{w.step}}
+          {{w.Step}}
         {{/step-manager}}
       </div>
     `);
@@ -242,7 +242,7 @@ module('step-manager', function (hooks) {
           <div data-test-steps>
             {{w.currentStep}}
 
-            {{w.step name='foo'}}
+            {{w.Step name='foo'}}
           </div>
         {{/step-manager}}
       `);
@@ -254,8 +254,8 @@ module('step-manager', function (hooks) {
       test('it exposes whether the step has a next step', async function (assert) {
         await render(hbs`
           {{#step-manager as |w|}}
-            {{w.step name='foo'}}
-            {{w.step name='bar'}}
+            {{w.Step name='foo'}}
+            {{w.Step name='bar'}}
 
             {{#each w.steps as |step|}}
               <p data-test-step={{step.name}}>
@@ -276,8 +276,8 @@ module('step-manager', function (hooks) {
       test('it exposes whether the step has a previous step', async function (assert) {
         await render(hbs`
           {{#step-manager as |w|}}
-            {{w.step name='foo'}}
-            {{w.step name='bar'}}
+            {{w.Step name='foo'}}
+            {{w.Step name='bar'}}
 
             {{#each w.steps as |step|}}
               <p data-test-step={{step.name}}>
@@ -298,8 +298,8 @@ module('step-manager', function (hooks) {
       test('it exposes whether the step is active', async function (assert) {
         await render(hbs`
           {{#step-manager as |w|}}
-            {{w.step name='foo'}}
-            {{w.step name='bar'}}
+            {{w.Step name='foo'}}
+            {{w.Step name='bar'}}
 
             {{#each w.steps as |step|}}
               <button {{action w.transition-to step}} data-test-step={{step.name}}>
@@ -329,12 +329,12 @@ module('step-manager', function (hooks) {
       test('can transition to a step by passing the node', async function (assert) {
         await render(hbs`
           {{#step-manager as |w|}}
-            {{#w.step name='foo'}}
+            {{#w.Step name='foo'}}
               <p data-test-step="foo">Foo</p>
-            {{/w.step}}
-            {{#w.step name='bar'}}
+            {{/w.Step}}
+            {{#w.Step name='bar'}}
               <p data-test-step="bar">Bar</p>
-            {{/w.step}}
+            {{/w.Step}}
 
             {{#each w.steps as |step|}}
               <button {{action w.transition-to step}} data-test-transition-to={{step.name}}>
@@ -357,7 +357,7 @@ module('step-manager', function (hooks) {
         test('it exposes step context', async function (assert) {
           await render(hbs`
             {{#step-manager as |w|}}
-              {{w.step name='foo' context='bar'}}
+              {{w.Step name='foo' context='bar'}}
 
               {{#each w.steps as |step|}}
                 <p data-test-step={{step.name}}>
@@ -375,7 +375,7 @@ module('step-manager', function (hooks) {
 
           await render(hbs`
             {{#step-manager as |w|}}
-              {{w.step name='foo' context=context}}
+              {{w.Step name='foo' context=context}}
 
               {{#each w.steps as |step|}}
                 <p data-test-step={{step.name}}>
@@ -401,7 +401,7 @@ module('step-manager', function (hooks) {
 
           await render(hbs`
             {{#step-manager as |w|}}
-              {{w.step name='foo' context=context}}
+              {{w.Step name='foo' context=context}}
 
               {{#each w.steps as |step|}}
                 <p data-test-step={{step.name}}>
@@ -428,13 +428,13 @@ module('step-manager', function (hooks) {
           await render(hbs`
             {{#step-manager as |w|}}
               <div data-test-active-step>
-                {{#w.step name='foo'}}
+                {{#w.Step name='foo'}}
                   Foo
-                {{/w.step}}
+                {{/w.Step}}
 
-                {{#w.step name='bar'}}
+                {{#w.Step name='bar'}}
                   Bar
-                {{/w.step}}
+                {{/w.Step}}
               </div>
 
               {{#each w.steps as |step|}}
@@ -466,13 +466,13 @@ module('step-manager', function (hooks) {
               {{/each}}
 
               <div data-test-active-step>
-                {{#w.step name='foo'}}
+                {{#w.Step name='foo'}}
                   Foo
-                {{/w.step}}
+                {{/w.Step}}
 
-                {{#w.step name='bar'}}
+                {{#w.Step name='bar'}}
                   Bar
-                {{/w.step}}
+                {{/w.Step}}
               </div>
             {{/step-manager}}
           `);
@@ -499,13 +499,13 @@ module('step-manager', function (hooks) {
             Transition to Next
           </button>
 
-          <w.step @name="first">
+          <w.Step @name="first">
             <div data-test-first></div>
-          </w.step>
+          </w.Step>
 
-          <w.step @name="second">
+          <w.Step @name="second">
             <div data-test-second></div>
-          </w.step>
+          </w.Step>
         </StepManager>
       `);
 
@@ -527,13 +527,13 @@ module('step-manager', function (hooks) {
             Next!
           </button>
 
-          {{#w.step name='first'}}
+          {{#w.Step name='first'}}
             <div data-test-first></div>
-          {{/w.step}}
+          {{/w.Step}}
 
-          {{#w.step name='second'}}
+          {{#w.Step name='second'}}
             <div data-test-second></div>
-          {{/w.step}}
+          {{/w.Step}}
         {{/step-manager}}
       `);
 
@@ -551,13 +551,13 @@ module('step-manager', function (hooks) {
             Next!
           </button>
 
-          {{#w.step name='first'}}
+          {{#w.Step name='first'}}
             <div data-test-first></div>
-          {{/w.step}}
+          {{/w.Step}}
 
-          {{#w.step name='second'}}
+          {{#w.Step name='second'}}
             <div data-test-second></div>
-          {{/w.step}}
+          {{/w.Step}}
         {{/step-manager}}
       `);
 
@@ -577,9 +577,9 @@ module('step-manager', function (hooks) {
             Next!
           </button>
 
-          {{#w.step name='first'}}
+          {{#w.Step name='first'}}
             <div data-test-first></div>
-          {{/w.step}}
+          {{/w.Step}}
         {{/step-manager}}
       `);
 
@@ -593,9 +593,9 @@ module('step-manager', function (hooks) {
             Next!
           </button>
 
-          {{#w.step name='first'}}
+          {{#w.Step name='first'}}
             <div data-test-first></div>
-          {{/w.step}}
+          {{/w.Step}}
         {{/step-manager}}
       `);
 
@@ -612,17 +612,17 @@ module('step-manager', function (hooks) {
               Next!
             </button>
 
-            {{#w.step name='first'}}
+            {{#w.Step name='first'}}
               <div data-test-first></div>
-            {{/w.step}}
+            {{/w.Step}}
 
-            {{#w.step name='second'}}
+            {{#w.Step name='second'}}
               <div data-test-second></div>
-            {{/w.step}}
+            {{/w.Step}}
 
-            {{#w.step name='third'}}
+            {{#w.Step name='third'}}
               <div data-test-third></div>
-            {{/w.step}}
+            {{/w.Step}}
           {{/step-manager}}
         `);
 
@@ -659,17 +659,17 @@ module('step-manager', function (hooks) {
               Next!
             </button>
 
-            {{#w.step name='first'}}
+            {{#w.Step name='first'}}
               <div data-test-first></div>
-            {{/w.step}}
+            {{/w.Step}}
 
-            {{#w.step name='second'}}
+            {{#w.Step name='second'}}
               <div data-test-second></div>
-            {{/w.step}}
+            {{/w.Step}}
 
-            {{#w.step name='third'}}
+            {{#w.Step name='third'}}
               <div data-test-third></div>
-            {{/w.step}}
+            {{/w.Step}}
           {{/step-manager}}
         `);
 
@@ -708,11 +708,11 @@ module('step-manager', function (hooks) {
         {{#step-manager as |w|}}
           <div data-test-steps>
             {{#each data as |item|}}
-              {{#w.step}}
+              {{#w.Step}}
                 <div data-test-step={{item.name}}>
                   {{item.name}}
                 </div>
-              {{/w.step}}
+              {{/w.Step}}
             {{/each}}
           </div>
 
@@ -738,11 +738,11 @@ module('step-manager', function (hooks) {
         {{#step-manager linear=false as |w|}}
           <div data-test-steps>
             {{#each data as |item|}}
-              {{#w.step name=item.name}}
+              {{#w.Step name=item.name}}
                 <div data-test-step={{item.name}}>
                   {{item.name}}
                 </div>
-              {{/w.step}}
+              {{/w.Step}}
             {{/each}}
           </div>
 
@@ -783,11 +783,11 @@ module('step-manager', function (hooks) {
         {{#step-manager linear=false as |w|}}
           <div data-test-steps>
             {{#each data as |item|}}
-              {{#w.step name=item.name}}
+              {{#w.Step name=item.name}}
                 <div data-test-step={{item.name}}>
                   {{item.name}}
                 </div>
-              {{/w.step}}
+              {{/w.Step}}
             {{/each}}
           </div>
 
@@ -833,11 +833,11 @@ module('step-manager', function (hooks) {
         {{#step-manager linear=true as |w|}}
           <div data-test-steps>
             {{#each data as |item|}}
-              {{#w.step name=item.name}}
+              {{#w.Step name=item.name}}
                 <div data-test-step={{item.name}}>
                   {{item.name}}
                 </div>
-              {{/w.step}}
+              {{/w.Step}}
             {{/each}}
           </div>
         {{/step-manager}}
@@ -862,11 +862,11 @@ module('step-manager', function (hooks) {
         {{#step-manager linear=false as |w|}}
           <div data-test-steps>
             {{#each data as |item|}}
-              {{#w.step name=item.name}}
+              {{#w.Step name=item.name}}
                 <div data-test-step={{item.name}}>
                   {{item.name}}
                 </div>
-              {{/w.step}}
+              {{/w.Step}}
             {{/each}}
           </div>
 
@@ -899,13 +899,13 @@ module('step-manager', function (hooks) {
     test('it handles steps with falsy names', async function (assert) {
       await render(hbs`
         {{#step-manager initialStep='' as |w|}}
-          {{#w.step name=''}}
+          {{#w.Step name=''}}
             <div data-test-empty-string></div>
-          {{/w.step}}
+          {{/w.Step}}
 
-          {{#w.step name=0}}
+          {{#w.Step name=0}}
             <div data-test-zero></div>
-          {{/w.step}}
+          {{/w.Step}}
 
           <button {{action w.transition-to-previous}} data-test-previous>
             Previous step

--- a/tests/integration/step-manager/step-test.js
+++ b/tests/integration/step-manager/step-test.js
@@ -125,10 +125,10 @@ module('step-manger/step', function (hooks) {
     test('when it has a next step', async function (assert) {
       await render(hbs`
         {{#step-manager as |w|}}
-          {{#w.step as |step|}}
+          {{#w.Step as |step|}}
             <p>{{step.hasNext}}</p>
-          {{/w.step}}
-          {{w.step}}
+          {{/w.Step}}
+          {{w.Step}}
         {{/step-manager}}
       `);
 
@@ -138,9 +138,9 @@ module('step-manger/step', function (hooks) {
     test('when it does not have a next step', async function (assert) {
       await render(hbs`
         {{#step-manager as |w|}}
-          {{#w.step as |step|}}
+          {{#w.Step as |step|}}
             <p>{{step.hasNext}}</p>
-          {{/w.step}}
+          {{/w.Step}}
         {{/step-manager}}
       `);
 
@@ -152,10 +152,10 @@ module('step-manger/step', function (hooks) {
     test('when it has a previous step', async function (assert) {
       await render(hbs`
         {{#step-manager currentStep='bar' as |w|}}
-          {{w.step name='foo'}}
-          {{#w.step name='bar' as |step|}}
+          {{w.Step name='foo'}}
+          {{#w.Step name='bar' as |step|}}
             <p>{{step.hasPrevious}}</p>
-          {{/w.step}}
+          {{/w.Step}}
         {{/step-manager}}
       `);
 
@@ -165,9 +165,9 @@ module('step-manger/step', function (hooks) {
     test('when it does not have a previous step', async function (assert) {
       await render(hbs`
         {{#step-manager as |w|}}
-          {{#w.step as |step|}}
+          {{#w.Step as |step|}}
             <p>{{step.hasPrevious}}</p>
-          {{/w.step}}
+          {{/w.Step}}
         {{/step-manager}}
       `);
 


### PR DESCRIPTION
Closes #166

BREAKING CHANGE: The `Step` component is now yielded as `w.Step`, using the capitalization to denote the fact that the thing being yielded is a component