### PR TITLE
feat: widen tracked-maps-and-sets versions range to allow both v2 and v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@glimmer/tracking": "^1.0.0",
     "ember-cli-babel": "^7.20.5",
     "ember-cli-htmlbars": "^6.0.0",
-    "tracked-maps-and-sets": "^3.0.1"
+    "tracked-maps-and-sets": "^2.2.1 || ^3.0.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16083,7 +16083,7 @@ tr46@~0.0.1:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-tracked-maps-and-sets@^3.0.1:
+"tracked-maps-and-sets@^2.2.1 || ^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/tracked-maps-and-sets/-/tracked-maps-and-sets-3.0.2.tgz#6ea1b9f2a367d24f2e9905b74b24437fbce76ea6"
   integrity sha512-UIRcWsX1kDOcC/Q2R58weYWlw01EnmWWBwUv3okWS+zMBvsgIfYoO6veHhuNE3hgzWCEImNp46QS5CyKnw5QUA==


### PR DESCRIPTION
this change allows the consuming app to use either v2 or v3.

Comes in handy when app has many dependencies where some depend on v2 while others use v3 so that upgrade of dependencies does not stuck.